### PR TITLE
fix `set` feature when adding a new root hierarchy

### DIFF
--- a/sops.go
+++ b/sops.go
@@ -148,10 +148,11 @@ func set(branch interface{}, path []interface{}, value interface{}) interface{} 
 			}
 		}
 		// Not found, need to add the next path entry to the branch
-		if len(path) == 1 {
-			return append(branch, TreeItem{Key: path[0], Value: value})
+		value := valueFromPathAndLeaf(path, value)
+		if newBranch, ok := value.(TreeBranch); ok && len(newBranch) > 0 {
+			return append(branch, newBranch[0])
 		}
-		return valueFromPathAndLeaf(path, value)
+		return branch
 	case []interface{}:
 		position := path[0].(int)
 		if len(path) == 1 {

--- a/sops_test.go
+++ b/sops_test.go
@@ -577,6 +577,36 @@ func TestSetNewKey(t *testing.T) {
 	assert.Equal(t, "hello", set[0].Value.(TreeBranch)[0].Value.(TreeBranch)[1].Value)
 }
 
+func TestSetNewBranch(t *testing.T) {
+	branch := TreeBranch{
+		TreeItem{
+			Key:   "key",
+			Value: "value",
+		},
+	}
+	set := branch.Set([]interface{}{"foo", "bar", "baz"}, "hello")
+	assert.Equal(t, TreeBranch{
+		TreeItem{
+			Key:   "key",
+			Value: "value",
+		},
+		TreeItem{
+			Key: "foo",
+			Value: TreeBranch{
+				TreeItem{
+					Key: "bar",
+					Value: TreeBranch{
+						TreeItem{
+							Key:   "baz",
+							Value: "hello",
+						},
+					},
+				},
+			},
+		},
+	}, set)
+}
+
 func TestSetArrayDeepNew(t *testing.T) {
 	branch := TreeBranch{
 		TreeItem{


### PR DESCRIPTION
fixes #407

with this fix, when adding a new root hierarchy, the existing root entries won't be dropped anymore