### PR TITLE
introduce a --pristine flag to sops exec-env

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -137,6 +137,10 @@ func main() {
 					Name:  "background",
 					Usage: "background the process and don't wait for it to complete",
 				},
+				cli.BoolFlag{
+					Name:  "pristine",
+					Usage: "insert only the decrypted values into the environment without forwarding existing environment variables",
+				},
 				cli.StringFlag{
 					Name:  "user",
 					Usage: "the user to run the command as",
@@ -171,6 +175,7 @@ func main() {
 					Command:    command,
 					Plaintext:  output,
 					Background: c.Bool("background"),
+					Pristine:   c.Bool("pristine"),
 					User:       c.String("user"),
 				}); err != nil {
 					return toExitError(err)

--- a/cmd/sops/subcommand/exec/exec.go
+++ b/cmd/sops/subcommand/exec/exec.go
@@ -21,6 +21,7 @@ type ExecOpts struct {
 	Command    string
 	Plaintext  []byte
 	Background bool
+	Pristine   bool
 	Fifo       bool
 	User       string
 	Filename   string
@@ -83,7 +84,12 @@ func ExecWithEnv(opts ExecOpts) error {
 		SwitchUser(opts.User)
 	}
 
-	env := os.Environ()
+	var env []string
+
+	if !opts.Pristine {
+		env = os.Environ()
+	}
+
 	lines := bytes.Split(opts.Plaintext, []byte("\n"))
 	for _, line := range lines {
 		if len(line) == 0 {


### PR DESCRIPTION
The purpose of this flag is to modify the exec-env's behaviour to only insert decrypted secrets into the environment of the supplied command, without forwarding any of the existing environment variables. 

This is useful in cases where the environment needs to be sanitized from the existing environment variables.

This feature is inspired by [envconsul](https://github.com/hashicorp/envconsul)'s --pristine flag
