### PR TITLE
Respect aws_profile from Keygroup Config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -776,6 +776,7 @@ like so:
                       context:
                           foo: bar
                     - arn: arn2
+                      aws_profile: myprofile
               # Second key group
               - pgp:
                     - fingerprint3
@@ -818,6 +819,7 @@ with ``shamir_threshold``:
                       context:
                           foo: bar
                     - arn: arn2
+                      aws_profile: myprofile
               # Second key group
               - pgp:
                     - fingerprint3

--- a/config/config.go
+++ b/config/config.go
@@ -164,7 +164,7 @@ func getKeyGroupsFromCreationRule(cRule *creationRule, kmsEncryptionContext map[
 				keyGroup = append(keyGroup, pgp.NewMasterKeyFromFingerprint(k))
 			}
 			for _, k := range group.KMS {
-				keyGroup = append(keyGroup, kms.NewMasterKey(k.Arn, k.Role, k.Context))
+				keyGroup = append(keyGroup, kms.NewMasterKeyWithProfile(k.Arn, k.Role, k.Context, k.AwsProfile))
 			}
 			for _, k := range group.GCPKMS {
 				keyGroup = append(keyGroup, gcpkms.NewMasterKeyFromResourceID(k.ResourceID))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -93,6 +93,7 @@ creation_rules:
     key_groups:
     - kms:
       - arn: foo
+        aws_profile: bar
       pgp:
       - bar
       gcp_kms:
@@ -105,6 +106,7 @@ creation_rules:
       - 'https://foo.vault:8200/v1/foo/keys/foo-key'
     - kms:
       - arn: baz
+        aws_profile: foo
       pgp:
       - qux
       gcp_kms:
@@ -287,14 +289,14 @@ func TestLoadConfigFileWithGroups(t *testing.T) {
 				PathRegex: "",
 				KeyGroups: []keyGroup{
 					{
-						KMS:     []kmsKey{{Arn: "foo"}},
+						KMS:     []kmsKey{{Arn: "foo", AwsProfile: "bar"}},
 						PGP:     []string{"bar"},
 						GCPKMS:  []gcpKmsKey{{ResourceID: "foo"}},
 						AzureKV: []azureKVKey{{VaultURL: "https://foo.vault.azure.net", Key: "foo-key", Version: "fooversion"}},
 						Vault:   []string{"https://foo.vault:8200/v1/foo/keys/foo-key"},
 					},
 					{
-						KMS: []kmsKey{{Arn: "baz"}},
+						KMS: []kmsKey{{Arn: "baz", AwsProfile: "foo"}},
 						PGP: []string{"qux"},
 						GCPKMS: []gcpKmsKey{
 							{ResourceID: "bar"},

--- a/kms/keysource.go
+++ b/kms/keysource.go
@@ -88,6 +88,14 @@ func NewMasterKey(arn string, role string, context map[string]*string) *MasterKe
 	}
 }
 
+// NewMasterKeyWithProfile creates a new MasterKey from an ARN, role, context
+// and awsProfile, setting the creation date to the current date.
+func NewMasterKeyWithProfile(arn string, role string, context map[string]*string, awsProfile string) *MasterKey {
+	k := NewMasterKey(arn, role, context)
+	k.AwsProfile = awsProfile
+	return k
+}
+
 // NewMasterKeyFromArn takes an ARN string and returns a new MasterKey for that
 // ARN.
 func NewMasterKeyFromArn(arn string, context map[string]*string, awsProfile string) *MasterKey {

--- a/kms/keysource_test.go
+++ b/kms/keysource_test.go
@@ -122,6 +122,22 @@ func TestNewMasterKey(t *testing.T) {
 	assert.NotNil(t, key.CreationDate)
 }
 
+func TestNewMasterKeyWithProfile(t *testing.T) {
+	var (
+		dummyRole              = "a-role"
+		dummyEncryptionContext = map[string]*string{
+			"foo": aws.String("bar"),
+		}
+		dummyProfile = "a-profile"
+	)
+	key := NewMasterKeyWithProfile(dummyARN, dummyRole, dummyEncryptionContext, dummyProfile)
+	assert.Equal(t, dummyARN, key.Arn)
+	assert.Equal(t, dummyRole, key.Role)
+	assert.Equal(t, dummyEncryptionContext, key.EncryptionContext)
+	assert.Equal(t, dummyProfile, key.AwsProfile)
+	assert.NotNil(t, key.CreationDate)
+}
+
 func TestNewMasterKeyFromArn(t *testing.T) {
 	t.Run("arn", func(t *testing.T) {
 		var (


### PR DESCRIPTION
A KMS entry in a creation_rule keygroup supports setting aws_profile, but the value is not passed into the KMS MasterKey.

Fixes: #1093