### PR TITLE
Ensure stable order of SOPS parameters in dotenv file

### DIFF
--- a/stores/dotenv/store.go
+++ b/stores/dotenv/store.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/getsops/sops/v3"
@@ -98,7 +99,14 @@ func (store *Store) EmitEncryptedFile(in sops.Tree) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	for key, value := range mdItems {
+	var keys []string
+	for k := range mdItems {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		var value = mdItems[key]
 		if value == nil {
 			continue
 		}

--- a/stores/dotenv/store_test.go
+++ b/stores/dotenv/store_test.go
@@ -63,3 +63,20 @@ func TestEmitValueNonstring(t *testing.T) {
 	_, err := (&Store{}).EmitValue(BRANCH)
 	assert.NotNil(t, err)
 }
+
+func TestEmitEncryptedFileStability(t *testing.T) {
+	// emit the same tree multiple times to ensure the output is stable
+	// i.e. emitting the same tree always yields exactly the same output
+	var previous []byte
+	for i := 0; i < 10; i += 1 {
+		bytes, err := (&Store{}).EmitEncryptedFile(sops.Tree{
+			Branches: []sops.TreeBranch{{}},
+		})
+		assert.Nil(t, err)
+		assert.NotEmpty(t, bytes)
+		if previous != nil {
+			assert.Equal(t, previous, bytes)
+		}
+		previous = bytes
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/mozilla/sops/issues/565 by sorting the parameters as suggested by @autrilla (implementation by @Jdban) 

Built on top of https://github.com/mozilla/sops/pull/575

The test reliably fails if I comment out line 106 `sort.Strings(keys)`