### PR TITLE
Sort masterkeys to try offline decrypt methods first

### DIFF
--- a/keyservice/keyservice.go
+++ b/keyservice/keyservice.go
@@ -82,3 +82,13 @@ func KeyFromMasterKey(mk keys.MasterKey) Key {
 		panic(fmt.Sprintf("Tried to convert unknown MasterKey type %T to keyservice.Key", mk))
 	}
 }
+
+// IsOfflineMethod returns true for offline decrypt methods or false otherwise
+func IsOfflineMethod(mk keys.MasterKey) bool {
+	switch mk.(type) {
+	case *pgp.MasterKey, *age.MasterKey:
+		return true
+	default:
+		return false
+	}
+}

--- a/sops_test.go
+++ b/sops_test.go
@@ -6,6 +6,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/getsops/sops/v3/age"
+	"github.com/getsops/sops/v3/hcvault"
+	"github.com/getsops/sops/v3/pgp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -757,4 +760,11 @@ func TestEmitAsMap(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Equal(t, expected, data)
 	}
+}
+
+func TestSortKeyGroupIndices(t *testing.T) {
+	group := KeyGroup{&hcvault.MasterKey{}, &age.MasterKey{}, &pgp.MasterKey{}}
+	expected := []int{1, 2, 0}
+	indices := sortKeyGroupIndices(group)
+	assert.Equal(t, expected, indices)
 }


### PR DESCRIPTION
This is to address #305. Sort master keys so PGP/age keys appear before the others and being used first.