### PR TITLE
Allow shamir_threshold: 1

### DIFF
--- a/shamir/shamir.go
+++ b/shamir/shamir.go
@@ -175,8 +175,8 @@ func Split(secret []byte, parts, threshold int) ([][]byte, error) {
 	if parts > 255 {
 		return nil, fmt.Errorf("parts cannot exceed 255")
 	}
-	if threshold < 2 {
-		return nil, fmt.Errorf("threshold must be at least 2")
+	if threshold < 1 {
+		return nil, fmt.Errorf("threshold must be at least 1")
 	}
 	if threshold > 255 {
 		return nil, fmt.Errorf("threshold cannot exceed 255")
@@ -238,9 +238,9 @@ func Split(secret []byte, parts, threshold int) ([][]byte, error) {
 // Combine is used to reverse a Split and reconstruct a secret
 // once a `threshold` number of parts are available.
 func Combine(parts [][]byte) ([]byte, error) {
-	// Verify enough parts provided
-	if len(parts) < 2 {
-		return nil, fmt.Errorf("less than two parts cannot be used to reconstruct the secret")
+	// Verify some parts provided
+	if len(parts) < 1 {
+		return nil, fmt.Errorf("no parts cannot be used to reconstruct the secret")
 	}
 
 	// Verify the parts are all the same length

--- a/shamir/shamir_test.go
+++ b/shamir/shamir_test.go
@@ -20,12 +20,27 @@ func TestSplit_invalid(t *testing.T) {
 		t.Fatalf("expect error")
 	}
 
-	if _, err := Split(secret, 10, 1); err == nil {
-		t.Fatalf("expect error")
-	}
-
 	if _, err := Split(nil, 3, 2); err == nil {
 		t.Fatalf("expect error")
+	}
+}
+
+func TestSplit_single(t *testing.T) {
+	secret := []byte("test")
+
+	out, err := Split(secret, 5, 1)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if len(out) != 5 {
+		t.Fatalf("bad: %v", out)
+	}
+
+	for _, share := range out {
+		if len(share) != len(secret)+1 {
+			t.Fatalf("bad: %v", out)
+		}
 	}
 }
 
@@ -78,6 +93,29 @@ func TestCombine_invalid(t *testing.T) {
 	}
 	if _, err := Combine(parts); err == nil {
 		t.Fatalf("should err")
+	}
+}
+
+func TestCombine_single(t *testing.T) {
+	secret := []byte("test")
+
+	out, err := Split(secret, 5, 1)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// All of the parts should be able to "combine"
+	for i := 0; i < 5; i++ {
+		parts := [][]byte{out[i]}
+		recomb, err := Combine(parts)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		if !bytes.Equal(recomb, secret) {
+			t.Errorf("parts: (i:%d) %v", i, parts)
+			t.Fatalf("bad: %v %v", recomb, secret)
+		}
 	}
 }
 


### PR DESCRIPTION
This allows the case where multiple keygroups are used, but any one of the groups needs to be able to decrypt the secret. This is for example useful if some people use age keys and some use pgp, but each of them should be able to decrypt the secret by themselves.

Fixes: #878