### PR TITLE
Do not report version when upstream check fails

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -26,11 +26,12 @@ func PrintVersion(c *cli.Context) {
 		outdated, err := AIsNewerThanB(upstreamVersion, Version)
 		if err != nil {
 			out += fmt.Sprintf("\n[warning] failed to compare current version with latest: %v\n", err)
-		}
-		if outdated {
-			out += fmt.Sprintf("\n[info] sops %s is available, update with `go get -u github.com/getsops/sops/v3/cmd/sops`\n", upstreamVersion)
 		} else {
-			out += " (latest)\n"
+			if outdated {
+				out += fmt.Sprintf("\n[info] sops %s is available, update with `go get -u github.com/getsops/sops/v3/cmd/sops`\n", upstreamVersion)
+			} else {
+				out += " (latest)\n"
+			}
 		}
 	}
 	fmt.Fprintf(c.App.Writer, "%s", out)


### PR DESCRIPTION
... otherwise you could get something like the following (here sops is run without network connection available):
```
$ ./sops --version
sops 3.7.3
[warning] failed to retrieve latest version from upstream: Get "https://raw.githubusercontent.com/mozilla/sops/master/version/version.go": dial tcp: lookup raw.githubusercontent.com: Temporary failure in name resolution

[warning] failed to compare current version with latest: Version string empty
 (latest)
$
```
