### PR TITLE
Add SSH support for age

### DIFF
--- a/age/tui.go
+++ b/age/tui.go
@@ -1,0 +1,53 @@
+// These functions have been copied from the age project
+// https://github.com/FiloSottile/age/blob/v1.0.0/cmd/age/encrypted_keys.go
+// Copyright 2021 The age Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package age
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"golang.org/x/term"
+)
+
+// readPassphrase reads a passphrase from the terminal. It does not read from a
+// non-terminal stdin, so it does not check stdinInUse.
+func readPassphrase(prompt string) ([]byte, error) {
+	var in, out *os.File
+	if runtime.GOOS == "windows" {
+		var err error
+		in, err = os.OpenFile("CONIN$", os.O_RDWR, 0)
+		if err != nil {
+			return nil, err
+		}
+		defer in.Close()
+		out, err = os.OpenFile("CONOUT$", os.O_WRONLY, 0)
+		if err != nil {
+			return nil, err
+		}
+		defer out.Close()
+	} else if _, err := os.Stat("/dev/tty"); err == nil {
+		tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+		if err != nil {
+			return nil, err
+		}
+		defer tty.Close()
+		in, out = tty, tty
+	} else {
+		if !term.IsTerminal(int(os.Stdin.Fd())) {
+			return nil, fmt.Errorf("standard input is not a terminal, and /dev/tty is not available: %v", err)
+		}
+		in, out = os.Stdin, os.Stderr
+	}
+	fmt.Fprintf(out, "%s ", prompt)
+	// Use CRLF to work around an apparent bug in WSL2's handling of CONOUT$.
+	// Only when running a Windows binary from WSL2, the cursor would not go
+	// back to the start of the line with a simple LF. Honestly, it's impressive
+	// CONIN$ and CONOUT$ even work at all inside WSL2.
+	defer fmt.Fprintf(out, "\r\n")
+	return term.ReadPassword(int(in.Fd()))
+}

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
 	github.com/urfave/cli v1.22.14
+	golang.org/x/crypto v0.17.0
 	golang.org/x/net v0.19.0
 	golang.org/x/sys v0.15.0
 	golang.org/x/term v0.15.0
@@ -50,6 +51,7 @@ require (
 	cloud.google.com/go/compute v1.23.3 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v1.1.5 // indirect
+	filippo.io/edwards25519 v1.0.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.0.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
@@ -123,7 +125,6 @@ require (
 	go.opentelemetry.io/otel v1.21.0 // indirect
 	go.opentelemetry.io/otel/metric v1.21.0 // indirect
 	go.opentelemetry.io/otel/trace v1.21.0 // indirect
-	golang.org/x/crypto v0.17.0 // indirect
 	golang.org/x/mod v0.9.0 // indirect
 	golang.org/x/oauth2 v0.15.0 // indirect
 	golang.org/x/sync v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ cloud.google.com/go/storage v1.36.0 h1:P0mOkAcaJxhCTvAkMhxMfrTKiNcub4YmmPBtlhAyT
 cloud.google.com/go/storage v1.36.0/go.mod h1:M6M/3V/D3KpzMTJyPOR/HU6n2Si5QdaXYEsng2xgOs8=
 filippo.io/age v1.1.1 h1:pIpO7l151hCnQ4BdyBujnGP2YlUo0uj6sAVNHGBvXHg=
 filippo.io/age v1.1.1/go.mod h1:l03SrzDUrBkdBx8+IILdnn2KZysqQdbEBUQ4p3sqEQE=
+filippo.io/edwards25519 v1.0.0 h1:0wAIcmJUqRdI8IJ/3eGi5/HwXZWPujYXXlkrQogz0Ek=
+filippo.io/edwards25519 v1.0.0/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.1 h1:lGlwhPtrX6EVml1hO0ivjkUxsSyl4dsiw9qcA1k/3IQ=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.1/go.mod h1:RKUqNu35KJYcVG/fqTRqmuXJZYNhYkBrnC/hX7yGbTA=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.4.0 h1:BMAjVKJM0U/CYF27gA0ZMmXGkOcvfFtD0oHVZ1TIPRI=


### PR DESCRIPTION
This MR implements https://github.com/mozilla/sops/issues/692

I realize there is already a MR https://github.com/mozilla/sops/pull/898 but it implements the ssh encryption as a completely new method.
I just patched the existing age module to also support ssh recipients and identities.

The behavior is the same as the original MR:
If there is no `SOPS_AGE_SSH_PRIVATE_KEY` env variable given, sops will check `~/.ssh/id_ed25519` and fallbacks to `~/.ssh/id_rsa`.

Would love to hear some thoughts on this.