### PR TITLE
build: update Go to 1.20

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -34,8 +34,8 @@ jobs:
           go-version: '1.20'
         id: go
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-      - uses: actions/cache@v2
+        uses: actions/checkout@v3
+      - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -53,13 +53,13 @@ jobs:
         run: make test
       - name: Upload artifact for Linux and Darwin
         if: matrix.os != 'windows'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: sops-${{ matrix.os }}-${{ matrix.arch }}-${{ github.sha }}
           path: sops-${{ matrix.os }}-${{ matrix.arch }}-${{ github.sha }}
       - name: Upload artifact for Windows
         if: matrix.os == 'windows'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: sops-${{ matrix.os }}-${{ github.sha }}
           path: sops-${{ matrix.os }}-${{ github.sha }}
@@ -75,8 +75,8 @@ jobs:
       - name: Install rustup
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y --default-toolchain 1.70.0
       - name: Check out code
-        uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+        uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: sops-linux-amd64-${{ github.sha }}
       - name: Move SOPS binary

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -28,10 +28,10 @@ jobs:
     steps:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install git -y
-      - name: Set up Go 1.19
-        uses: actions/setup-go@v2
+      - name: Set up Go 1.20
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: '1.20'
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -28,10 +28,10 @@ jobs:
     steps:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install git -y
-      - name: Set up Go 1.18
+      - name: Set up Go 1.19
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
       - name: Install fpm
         run: gem install fpm || sudo gem install fpm
       - name: Set up Go 1.20
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: '1.20'
         id: go
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Go vendor
         run: go mod vendor
       - name: Make release directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install git ruby rpm -y
       - name: Install fpm
         run: gem install fpm || sudo gem install fpm
-      - name: Set up Go 1.18
+      - name: Set up Go 1.19
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install git ruby rpm -y
       - name: Install fpm
         run: gem install fpm || sudo gem install fpm
-      - name: Set up Go 1.19
+      - name: Set up Go 1.20
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: '1.20'
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19
+FROM golang:1.20
 
 COPY . /go/src/go.mozilla.org/sops
 WORKDIR /go/src/go.mozilla.org/sops

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.19
 
 COPY . /go/src/go.mozilla.org/sops
 WORKDIR /go/src/go.mozilla.org/sops

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine3.16 AS builder
+FROM golang:1.20-alpine3.17 AS builder
 
 RUN apk --no-cache add make
 
@@ -8,7 +8,7 @@ WORKDIR /go/src/go.mozilla.org/sops
 RUN CGO_ENABLED=1 make install
 
 
-FROM alpine:3.16
+FROM alpine:3.17
 
 RUN apk --no-cache add \
   vim ca-certificates

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine3.17 AS builder
+FROM golang:1.20-alpine3.18 AS builder
 
 RUN apk --no-cache add make
 
@@ -8,7 +8,7 @@ WORKDIR /go/src/go.mozilla.org/sops
 RUN CGO_ENABLED=1 make install
 
 
-FROM alpine:3.17
+FROM alpine:3.18
 
 RUN apk --no-cache add \
   vim ca-certificates

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine3.16 AS builder
+FROM golang:1.19-alpine3.16 AS builder
 
 RUN apk --no-cache add make
 
@@ -8,7 +8,7 @@ WORKDIR /go/src/go.mozilla.org/sops
 RUN CGO_ENABLED=1 make install
 
 
-FROM alpine:3.15
+FROM alpine:3.16
 
 RUN apk --no-cache add \
   vim ca-certificates

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.mozilla.org/sops/v3
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/kms v1.4.0


### PR DESCRIPTION
This updates Go used for builds to 1.20, and updates a forgotten Alpine 3.15 version in a `Dockerfile` to 3.18.