### PR TITLE
gcpkms: fix WithCredentialsJSON to credentials

### DIFF
--- a/gcpkms/keysource.go
+++ b/gcpkms/keysource.go
@@ -217,7 +217,7 @@ func (key *MasterKey) newKMSClient() (*kms.KeyManagementClient, error) {
 			return nil, err
 		}
 		if credentials != nil {
-			opts = append(opts, option.WithCredentialsJSON(key.credentialJSON))
+			opts = append(opts, option.WithCredentialsJSON(credentials))
 		}
 	}
 	if key.grpcConn != nil {


### PR DESCRIPTION
gcpkms: fix `WithCredentialsJSON` to credentials.

The `key.credentialJSO` is already parsed, and this line condition is `if credentials != nil {`, so use the `credentials` variable.