### PR TITLE
Build: Bump go version to 1.20.5

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -28,14 +28,14 @@ jobs:
     steps:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install git -y
-      - name: Set up Go 1.18
-        uses: actions/setup-go@v2
+      - name: Set up Go 1.20.5
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.20.5
         id: go
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-      - uses: actions/cache@v2
+        uses: actions/checkout@v3
+      - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -53,13 +53,13 @@ jobs:
         run: make test
       - name: Upload artifact for Linux and Darwin
         if: matrix.os != 'windows'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: sops-${{ matrix.os }}-${{ matrix.arch }}-${{ github.sha }}
           path: sops-${{ matrix.os }}-${{ matrix.arch }}-${{ github.sha }}
       - name: Upload artifact for Windows
         if: matrix.os == 'windows'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: sops-${{ matrix.os }}-${{ github.sha }}
           path: sops-${{ matrix.os }}-${{ github.sha }}
@@ -75,8 +75,8 @@ jobs:
       - name: Install rustup
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y --default-toolchain 1.47.0
       - name: Check out code
-        uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+        uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: sops-linux-amd64-${{ github.sha }}
       - name: Move SOPS binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install git ruby rpm -y
       - name: Install fpm
         run: gem install fpm || sudo gem install fpm
-      - name: Set up Go 1.18
-        uses: actions/setup-go@v2
+      - name: Set up Go 1.20.5
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.20.5
         id: go
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Go vendor
         run: go mod vendor
       - name: Make release directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.20.5
 
 COPY . /go/src/go.mozilla.org/sops
 WORKDIR /go/src/go.mozilla.org/sops

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine3.16 AS builder
+FROM golang:1.20.5-alpine3.17 AS builder
 
 RUN apk --no-cache add make
 
@@ -8,7 +8,7 @@ WORKDIR /go/src/go.mozilla.org/sops
 RUN CGO_ENABLED=1 make install
 
 
-FROM alpine:3.15
+FROM alpine:3.17
 
 RUN apk --no-cache add \
   vim ca-certificates


### PR DESCRIPTION
Bumping Golang version to 1.20.5 to get rid of the CVEs present in Go runtime less than 1.20.5