### PR TITLE
Update rustc functional tests to v1.70.0

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -73,7 +73,7 @@ jobs:
       VAULT_ADDR: "http://127.0.0.1:8200"
     steps:
       - name: Install rustup
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y --default-toolchain 1.47.0
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y --default-toolchain 1.70.0
       - name: Check out code
         uses: actions/checkout@v2
       - uses: actions/download-artifact@v2

--- a/functional-tests/Cargo.toml
+++ b/functional-tests/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "functional-tests"
 version = "0.1.0"
+edition = "2021"
 authors = ["Adrian Utrilla <adrianutrilla@gmail.com>"]
 
 [dependencies]
 tempdir = "0.3.5"
 serde = "1.0"
-serde_json = "0.8"
-serde_yaml = "0.5"
+serde_json = "1.0.99"
+serde_yaml = "0.9.22"
 serde_derive = "1.0"
-lazy_static = "0.1.*"
+lazy_static = "1.4.0"

--- a/functional-tests/src/lib.rs
+++ b/functional-tests/src/lib.rs
@@ -624,7 +624,7 @@ b: ba"#
         assert!(output.status
                     .success(),
                 "SOPS failed to decrypt a binary file");
-        assert_eq!(output.stdout, &[]);
+        assert_eq!(output.stdout, <&[u8]>::default());
         let mut f = File::open(&output_path).expect("output file not found");
 
         let mut contents = String::new();


### PR DESCRIPTION
Bear minimum to get this going again, including an update of
dependencies.

It's worth noting that there is a detachment between the GitHub Action
workflow and running this locally. As there are assumptions around:

1. Having the `pgp/sops_functional_tests_key.asc` imported.
2. Having a Vault server running for two functional tests.

The `functional-tests` Make target does not facilitate this, and
putting something in place using a temporary `GNUPGHOME` and a
container image would likely be a welcome future improvement.

In addition, there is Rust code in `validation/` which appears to be an
artifact from an ancient Python library[1][2]. This should probably be
removed in the future.

[1]: https://github.com/getsops/sops/tree/python-sops
[2]: https://pypi.org/project/sops/