### PR TITLE
build: run CLI workflow on `main`

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -3,12 +3,10 @@ name: CLI
 on:
   push:
     branches:
-      - develop
-      - master
+      - main
   pull_request:
     branches:
-      - develop
-      - master
+      - main 
 
 jobs:
   build:


### PR DESCRIPTION
As `master` and `develop` are being laid to rest.

Part of #1238 and https://github.com/getsops/community/issues/16