### PR TITLE
Allow configuration of indentation for YAML and JSON stores

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1130,15 +1130,15 @@ Below is an example of publishing to Vault (using token auth with a local dev in
 Important information on types
 ------------------------------
 
-YAML and JSON type extensions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+YAML, JSON, ENV and INI type extensions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 SOPS uses the file extension to decide which encryption method to use on the file
 content. ``YAML``, ``JSON``, ``ENV``, and ``INI`` files are treated as trees of data, and key/values are
 extracted from the files to only encrypt the leaf values. The tree structure is also
 used to check the integrity of the file.
 
-Therefore, if a file is encrypted using a specific format, it need to be decrypted
+Therefore, if a file is encrypted using a specific format, it needs to be decrypted
 in the same format. The easiest way to achieve this is to conserve the original file
 extension after encrypting a file. For example:
 
@@ -1165,11 +1165,14 @@ When operating on stdin, use the ``--input-type`` and ``--output-type`` flags as
 JSON indentation
 ~~~~~~~~~~~~~~~~
 
-``sops`` indent ``SOPS`` files by default using one ``tab``. However, you can change
-this default behaviour to use spaces by either using the additional ``--indent=2`` cli option or
-by configuring ``.sops.yaml`` with the code below. (value ``0`` is no indentation)
+SOPS indents ``JSON`` files by default using one ``tab``. However, you can change
+this default behaviour to use ``spaces`` by either using the additional ``--indent=2`` CLI option or
+by configuring ``.sops.yaml`` with the code below.
+
+The special value ``0`` disables indentation, and ``-1`` uses a single tab.
 
 .. code:: yaml
+
   stores:
       json:
           indent: 2
@@ -1177,11 +1180,12 @@ by configuring ``.sops.yaml`` with the code below. (value ``0`` is no indentatio
 YAML indentation
 ~~~~~~~~~~~~~~~~
 
-``sops`` indent ``YAML`` files by default using 4 spaces. However, you can change
-this default behaviour by either using the additional ``--indent=2`` cli option or
-by configuring ``.sops.yaml`` with :
+SOPS indents ``YAML`` files by default using 4 spaces. However, you can change
+this default behaviour by either using the additional ``--indent=2`` CLI option or
+by configuring ``.sops.yaml`` with:
 
 .. code:: yaml
+
   stores:
       yaml:
           indent: 2

--- a/README.rst
+++ b/README.rst
@@ -1162,8 +1162,8 @@ When operating on stdin, use the ``--input-type`` and ``--output-type`` flags as
 
     $ cat myfile.json | sops --input-type json --output-type json -d /dev/stdin
 
-JSON indentation
-~~~~~~~~~~~~~~~~
+JSON and JSON_binary indentation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 SOPS indents ``JSON`` files by default using one ``tab``. However, you can change
 this default behaviour to use ``spaces`` by either using the additional ``--indent=2`` CLI option or
@@ -1175,6 +1175,8 @@ The special value ``0`` disables indentation, and ``-1`` uses a single tab.
 
   stores:
       json:
+          indent: 2
+      json_binary:
           indent: 2
 
 YAML indentation

--- a/README.rst
+++ b/README.rst
@@ -1162,8 +1162,22 @@ When operating on stdin, use the ``--input-type`` and ``--output-type`` flags as
 
     $ cat myfile.json | sops --input-type json --output-type json -d /dev/stdin
 
+YAML indentation
+~~~~~~~~~~~~~~~~
+
+``sops`` indent ``YAML`` files by default using 4 spaces. However, you can change
+this default behaviour be either using the additional ``--indent=2`` cli option or
+by configuring ``.sops.yaml`` with :
+
+.. code:: yaml
+  stores:
+      yaml:
+          indent: 2
+
+
 YAML anchors
 ~~~~~~~~~~~~
+
 SOPS only supports a subset of ``YAML``'s many types. Encrypting YAML files that
 contain strings, numbers and booleans will work fine, but files that contain anchors
 will not work, because the anchors redefine the structure of the file at load time.

--- a/README.rst
+++ b/README.rst
@@ -1166,8 +1166,8 @@ JSON indentation
 ~~~~~~~~~~~~~~~~
 
 ``sops`` indent ``SOPS`` files by default using one ``tab``. However, you can change
-this default behaviour to use spaces be either using the additional ``--indent=2`` cli option or
-by configuring ``.sops.yaml`` with :
+this default behaviour to use spaces by either using the additional ``--indent=2`` cli option or
+by configuring ``.sops.yaml`` with the code below. (value ``0`` is no indentation)
 
 .. code:: yaml
   stores:
@@ -1178,7 +1178,7 @@ YAML indentation
 ~~~~~~~~~~~~~~~~
 
 ``sops`` indent ``YAML`` files by default using 4 spaces. However, you can change
-this default behaviour be either using the additional ``--indent=2`` cli option or
+this default behaviour by either using the additional ``--indent=2`` cli option or
 by configuring ``.sops.yaml`` with :
 
 .. code:: yaml

--- a/README.rst
+++ b/README.rst
@@ -1162,6 +1162,18 @@ When operating on stdin, use the ``--input-type`` and ``--output-type`` flags as
 
     $ cat myfile.json | sops --input-type json --output-type json -d /dev/stdin
 
+JSON indentation
+~~~~~~~~~~~~~~~~
+
+``sops`` indent ``SOPS`` files by default using one ``tab``. However, you can change
+this default behaviour to use spaces be either using the additional ``--indent=2`` cli option or
+by configuring ``.sops.yaml`` with :
+
+.. code:: yaml
+  stores:
+      json:
+          indent: 2
+
 YAML indentation
 ~~~~~~~~~~~~~~~~
 
@@ -1173,7 +1185,6 @@ by configuring ``.sops.yaml`` with :
   stores:
       yaml:
           indent: 2
-
 
 YAML anchors
 ~~~~~~~~~~~~

--- a/cmd/sops/common/common.go
+++ b/cmd/sops/common/common.go
@@ -30,15 +30,10 @@ type ExampleFileEmitter interface {
 	EmitExample() []byte
 }
 
-type Configurable interface {
-	Configure(*config.Config)
-}
-
 // Store handles marshaling and unmarshaling from SOPS files
 type Store interface {
 	sops.Store
 	ExampleFileEmitter
-	Configurable
 }
 
 type storeConstructor = func(*config.StoresConfig) Store

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -704,6 +704,10 @@ func main() {
 			Name:  "shamir-secret-sharing-threshold",
 			Usage: "the number of master keys required to retrieve the data key with shamir",
 		},
+		cli.IntFlag{
+			Name:  "indent",
+			Usage: "the number of space to indent yaml encoded file for encryption",
+		},
 		cli.BoolFlag{
 			Name:  "verbose",
 			Usage: "Enable verbose logging output",
@@ -1087,6 +1091,9 @@ func outputStore(context *cli.Context, path string) common.Store {
 		configPath, _ = config.FindConfigFile(".")
 	}
 	storesConf, _ := config.LoadStoresConfig(configPath)
+	if context.Int("indent") != 0 {
+		storesConf.YAML.Indent = context.Int("indent")
+	}
 
 	return common.DefaultStoreForPathOrFormat(storesConf, path, context.String("output-type"))
 }

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -1091,6 +1091,7 @@ func outputStore(context *cli.Context, path string) common.Store {
 		indent := context.Int("indent")
 		storesConf.YAML.Indent = indent
 		storesConf.JSON.Indent = indent
+		storesConf.JSONBinary.Indent = indent
 	}
 
 	return common.DefaultStoreForPathOrFormat(storesConf, path, context.String("output-type"))

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -1088,7 +1088,9 @@ func inputStore(context *cli.Context, path string) common.Store {
 func outputStore(context *cli.Context, path string) common.Store {
 	storesConf, _ := loadStoresConfig(context, path)
 	if context.Int("indent") != 0 {
-		storesConf.YAML.Indent = context.Int("indent")
+		indent := context.Int("indent")
+		storesConf.YAML.Indent = indent
+		storesConf.JSON.Indent = indent
 	}
 
 	return common.DefaultStoreForPathOrFormat(storesConf, path, context.String("output-type"))

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -706,7 +706,7 @@ func main() {
 		},
 		cli.IntFlag{
 			Name:  "indent",
-			Usage: "the number of space to indent YAML encoded file for encryption",
+			Usage: "the number of spaces to indent YAML or JSON encoded file for encryption",
 		},
 		cli.BoolFlag{
 			Name:  "verbose",
@@ -1087,7 +1087,7 @@ func inputStore(context *cli.Context, path string) common.Store {
 
 func outputStore(context *cli.Context, path string) common.Store {
 	storesConf, _ := loadStoresConfig(context, path)
-	if context.Int("indent") != 0 {
+	if context.IsSet("indent") {
 		indent := context.Int("indent")
 		storesConf.YAML.Indent = indent
 		storesConf.JSON.Indent = indent

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -1066,11 +1066,29 @@ func keyservices(c *cli.Context) (svcs []keyservice.KeyServiceClient) {
 }
 
 func inputStore(context *cli.Context, path string) common.Store {
-	return common.DefaultStoreForPathOrFormat(path, context.String("input-type"))
+	var configPath string
+	if context.String("config") != "" {
+		configPath = context.String("config")
+	} else {
+		// Ignore config not found errors returned from FindConfigFile since the config file is not mandatory
+		configPath, _ = config.FindConfigFile(".")
+	}
+	storesConf, _ := config.LoadStoresConfig(configPath)
+
+	return common.DefaultStoreForPathOrFormat(storesConf, path, context.String("input-type"))
 }
 
 func outputStore(context *cli.Context, path string) common.Store {
-	return common.DefaultStoreForPathOrFormat(path, context.String("output-type"))
+	var configPath string
+	if context.String("config") != "" {
+		configPath = context.String("config")
+	} else {
+		// Ignore config not found errors returned from FindConfigFile since the config file is not mandatory
+		configPath, _ = config.FindConfigFile(".")
+	}
+	storesConf, _ := config.LoadStoresConfig(configPath)
+
+	return common.DefaultStoreForPathOrFormat(storesConf, path, context.String("output-type"))
 }
 
 func parseTreePath(arg string) ([]interface{}, error) {

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -706,7 +706,7 @@ func main() {
 		},
 		cli.IntFlag{
 			Name:  "indent",
-			Usage: "the number of space to indent yaml encoded file for encryption",
+			Usage: "the number of space to indent YAML encoded file for encryption",
 		},
 		cli.BoolFlag{
 			Name:  "verbose",
@@ -1069,7 +1069,7 @@ func keyservices(c *cli.Context) (svcs []keyservice.KeyServiceClient) {
 	return
 }
 
-func inputStore(context *cli.Context, path string) common.Store {
+func loadStoresConfig(context *cli.Context, path string) (*config.StoresConfig, error) {
 	var configPath string
 	if context.String("config") != "" {
 		configPath = context.String("config")
@@ -1077,20 +1077,16 @@ func inputStore(context *cli.Context, path string) common.Store {
 		// Ignore config not found errors returned from FindConfigFile since the config file is not mandatory
 		configPath, _ = config.FindConfigFile(".")
 	}
-	storesConf, _ := config.LoadStoresConfig(configPath)
+	return config.LoadStoresConfig(configPath)
+}
 
+func inputStore(context *cli.Context, path string) common.Store {
+	storesConf, _ := loadStoresConfig(context, path)
 	return common.DefaultStoreForPathOrFormat(storesConf, path, context.String("input-type"))
 }
 
 func outputStore(context *cli.Context, path string) common.Store {
-	var configPath string
-	if context.String("config") != "" {
-		configPath = context.String("config")
-	} else {
-		// Ignore config not found errors returned from FindConfigFile since the config file is not mandatory
-		configPath, _ = config.FindConfigFile(".")
-	}
-	storesConf, _ := config.LoadStoresConfig(configPath)
+	storesConf, _ := loadStoresConfig(context, path)
 	if context.Int("indent") != 0 {
 		storesConf.YAML.Indent = context.Int("indent")
 	}

--- a/cmd/sops/subcommand/updatekeys/updatekeys.go
+++ b/cmd/sops/subcommand/updatekeys/updatekeys.go
@@ -40,7 +40,11 @@ func UpdateKeys(opts Opts) error {
 }
 
 func updateFile(opts Opts) error {
-	store := common.DefaultStoreForPathOrFormat(opts.InputPath, opts.InputType)
+	sc, err := config.LoadStoresConfig(opts.ConfigPath)
+	if err != nil {
+		return err
+	}
+	store := common.DefaultStoreForPath(sc, opts.InputPath)
 	log.Printf("Syncing keys for file %s", opts.InputPath)
 	tree, err := common.LoadEncryptedFile(store, opts.InputPath)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -67,7 +67,9 @@ type DotenvStoreConfig struct{}
 
 type INIStoreConfig struct{}
 
-type JSONStoreConfig struct{}
+type JSONStoreConfig struct{
+	Indent int `yaml:"indent"`
+}
 
 type JSONBinaryStoreConfig struct{}
 

--- a/config/config.go
+++ b/config/config.go
@@ -63,9 +63,30 @@ func FindConfigFile(start string) (string, error) {
 	return "", fmt.Errorf("Config file not found")
 }
 
+type DotenvStoreConfig struct{}
+
+type INIStoreConfig struct{}
+
+type JSONStoreConfig struct{}
+
+type JSONBinaryStoreConfig struct{}
+
+type YAMLStoreConfig struct {
+	Indent int `yaml:"indent"`
+}
+
+type StoresConfig struct {
+	Dotenv     DotenvStoreConfig     `yaml:"dotenv"`
+	INI        INIStoreConfig        `yaml:"ini"`
+	JSONBinary JSONBinaryStoreConfig `yaml:"json_binary"`
+	JSON       JSONStoreConfig       `yaml:"json"`
+	YAML       YAMLStoreConfig       `yaml:"yaml"`
+}
+
 type configFile struct {
 	CreationRules    []creationRule    `yaml:"creation_rules"`
 	DestinationRules []destinationRule `yaml:"destination_rules"`
+	Stores           StoresConfig      `yaml:"stores"`
 }
 
 type keyGroup struct {
@@ -385,4 +406,12 @@ func LoadDestinationRuleForFile(confPath string, filePath string, kmsEncryptionC
 		return nil, err
 	}
 	return parseDestinationRuleForFile(conf, filePath, kmsEncryptionContext)
+}
+
+func LoadStoresConfig(confPath string) (*StoresConfig, error) {
+	conf, err := loadConfigFile(confPath)
+	if err != nil {
+		return nil, err
+	}
+	return &conf.Stores, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -149,6 +149,12 @@ type creationRule struct {
 	MACOnlyEncrypted  bool       `yaml:"mac_only_encrypted"`
 }
 
+func NewStoresConfig() *StoresConfig{
+	storesConfig := &StoresConfig{}	
+	storesConfig.JSON.Indent = -1
+	return storesConfig
+}
+
 // Load loads a sops config file into a temporary struct
 func (f *configFile) load(bytes []byte) error {
 	err := yaml.Unmarshal(bytes, f)
@@ -252,6 +258,7 @@ func loadConfigFile(confPath string) (*configFile, error) {
 		return nil, fmt.Errorf("could not read config file: %s", err)
 	}
 	conf := &configFile{}
+	conf.Stores = *NewStoresConfig()
 	err = conf.load(confBytes)
 	if err != nil {
 		return nil, fmt.Errorf("error loading config: %s", err)

--- a/config/config.go
+++ b/config/config.go
@@ -67,11 +67,13 @@ type DotenvStoreConfig struct{}
 
 type INIStoreConfig struct{}
 
-type JSONStoreConfig struct{
+type JSONStoreConfig struct {
 	Indent int `yaml:"indent"`
 }
 
-type JSONBinaryStoreConfig struct{}
+type JSONBinaryStoreConfig struct {
+	Indent int `yaml:"indent"`
+}
 
 type YAMLStoreConfig struct {
 	Indent int `yaml:"indent"`
@@ -149,9 +151,10 @@ type creationRule struct {
 	MACOnlyEncrypted  bool       `yaml:"mac_only_encrypted"`
 }
 
-func NewStoresConfig() *StoresConfig{
-	storesConfig := &StoresConfig{}	
+func NewStoresConfig() *StoresConfig {
+	storesConfig := &StoresConfig{}
 	storesConfig.JSON.Indent = -1
+	storesConfig.JSONBinary.Indent = -1
 	return storesConfig
 }
 

--- a/decrypt/decrypt.go
+++ b/decrypt/decrypt.go
@@ -12,6 +12,7 @@ import (
 	"github.com/getsops/sops/v3/aes"
 	"github.com/getsops/sops/v3/cmd/sops/common"
 	. "github.com/getsops/sops/v3/cmd/sops/formats" // Re-export
+	"github.com/getsops/sops/v3/config"
 )
 
 // File is a wrapper around Data that reads a local encrypted
@@ -32,7 +33,7 @@ func File(path, format string) (cleartext []byte, err error) {
 // decrypts the data and returns its cleartext in an []byte.
 func DataWithFormat(data []byte, format Format) (cleartext []byte, err error) {
 
-	store := common.StoreForFormat(format)
+	store := common.StoreForFormat(format, &config.StoresConfig{})
 
 	// Load SOPS file and access the data key
 	tree, err := store.LoadEncryptedFile(data)

--- a/decrypt/decrypt.go
+++ b/decrypt/decrypt.go
@@ -33,7 +33,7 @@ func File(path, format string) (cleartext []byte, err error) {
 // decrypts the data and returns its cleartext in an []byte.
 func DataWithFormat(data []byte, format Format) (cleartext []byte, err error) {
 
-	store := common.StoreForFormat(format, &config.StoresConfig{})
+	store := common.StoreForFormat(format, config.NewStoresConfig())
 
 	// Load SOPS file and access the data key
 	tree, err := store.LoadEncryptedFile(data)

--- a/stores/dotenv/store.go
+++ b/stores/dotenv/store.go
@@ -202,6 +202,3 @@ func isComplexValue(v interface{}) bool {
 	}
 	return false
 }
-
-func (store *Store) Configure(c *config.Config) {
-}

--- a/stores/dotenv/store.go
+++ b/stores/dotenv/store.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/getsops/sops/v3"
+	"github.com/getsops/sops/v3/config"
 	"github.com/getsops/sops/v3/stores"
 )
 
@@ -16,6 +17,11 @@ const SopsPrefix = "sops_"
 
 // Store handles storage of dotenv data
 type Store struct {
+	config config.DotenvStoreConfig
+}
+
+func NewStore(c *config.DotenvStoreConfig) *Store {
+	return &Store{config: *c}
 }
 
 // LoadEncryptedFile loads an encrypted file's bytes onto a sops.Tree runtime object
@@ -195,4 +201,7 @@ func isComplexValue(v interface{}) bool {
 		return true
 	}
 	return false
+}
+
+func (store *Store) Configure(c *config.Config) {
 }

--- a/stores/ini/store.go
+++ b/stores/ini/store.go
@@ -288,6 +288,3 @@ func (store *Store) EmitExample() []byte {
 	}
 	return bytes
 }
-
-func (store *Store) Configure(c *config.Config) {
-}

--- a/stores/ini/store.go
+++ b/stores/ini/store.go
@@ -9,12 +9,18 @@ import (
 	"strings"
 
 	"github.com/getsops/sops/v3"
+	"github.com/getsops/sops/v3/config"
 	"github.com/getsops/sops/v3/stores"
 	"gopkg.in/ini.v1"
 )
 
 // Store handles storage of ini data.
 type Store struct {
+	config *config.INIStoreConfig
+}
+
+func NewStore(c *config.INIStoreConfig) *Store {
+	return &Store{config: c}
 }
 
 func (store Store) encodeTree(branches sops.TreeBranches) ([]byte, error) {
@@ -281,4 +287,7 @@ func (store *Store) EmitExample() []byte {
 		panic(err)
 	}
 	return bytes
+}
+
+func (store *Store) Configure(c *config.Config) {
 }

--- a/stores/json/store.go
+++ b/stores/json/store.go
@@ -250,7 +250,7 @@ func (store Store) treeBranchFromJSON(in []byte) (sops.TreeBranch, error) {
 func (store Store) reindentJSON(in []byte) ([]byte, error) {
 	var out bytes.Buffer
 	indent := "\t"
-	if store.config.Indent != 0 {
+	if store.config.Indent != -1 {
 		indent = strings.Repeat(" ", store.config.Indent)
 	}
 	err := json.Indent(&out, in, "", indent)

--- a/stores/json/store.go
+++ b/stores/json/store.go
@@ -250,8 +250,10 @@ func (store Store) treeBranchFromJSON(in []byte) (sops.TreeBranch, error) {
 func (store Store) reindentJSON(in []byte) ([]byte, error) {
 	var out bytes.Buffer
 	indent := "\t"
-	if store.config.Indent != -1 {
+	if store.config.Indent > -1 {
 		indent = strings.Repeat(" ", store.config.Indent)
+	} else if store.config.Indent < -1 {
+		return nil, errors.New("JSON Indentation parameter smaller than -1 is not accepted")
 	}
 	err := json.Indent(&out, in, "", indent)
 	return out.Bytes(), err

--- a/stores/json/store.go
+++ b/stores/json/store.go
@@ -8,16 +8,27 @@ import (
 	"io"
 
 	"github.com/getsops/sops/v3"
+	"github.com/getsops/sops/v3/config"
 	"github.com/getsops/sops/v3/stores"
 )
 
 // Store handles storage of JSON data.
 type Store struct {
+	config config.JSONStoreConfig
+}
+
+func NewStore(c *config.JSONStoreConfig) *Store {
+	return &Store{config: *c}
 }
 
 // BinaryStore handles storage of binary data in a JSON envelope.
 type BinaryStore struct {
-	store Store
+	store  Store
+	config config.JSONBinaryStoreConfig
+}
+
+func NewBinaryStore(c *config.JSONBinaryStoreConfig) *BinaryStore {
+	return &BinaryStore{config: *c}
 }
 
 // LoadEncryptedFile loads an encrypted json file onto a sops.Tree object
@@ -336,4 +347,10 @@ func (store *Store) EmitExample() []byte {
 		panic(err)
 	}
 	return bytes
+}
+
+func (store *Store) Configure(c *config.Config) {
+}
+
+func (store *BinaryStore) Configure(c *config.Config) {
 }

--- a/stores/json/store.go
+++ b/stores/json/store.go
@@ -348,9 +348,3 @@ func (store *Store) EmitExample() []byte {
 	}
 	return bytes
 }
-
-func (store *Store) Configure(c *config.Config) {
-}
-
-func (store *BinaryStore) Configure(c *config.Config) {
-}

--- a/stores/json/store.go
+++ b/stores/json/store.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/getsops/sops/v3"
 	"github.com/getsops/sops/v3/config"
@@ -248,7 +249,11 @@ func (store Store) treeBranchFromJSON(in []byte) (sops.TreeBranch, error) {
 
 func (store Store) reindentJSON(in []byte) ([]byte, error) {
 	var out bytes.Buffer
-	err := json.Indent(&out, in, "", "\t")
+	indent := "\t"
+	if store.config.Indent != 0 {
+		indent = strings.Repeat(" ", store.config.Indent)
+	}
+	err := json.Indent(&out, in, "", indent)
 	return out.Bytes(), err
 }
 

--- a/stores/json/store.go
+++ b/stores/json/store.go
@@ -29,7 +29,9 @@ type BinaryStore struct {
 }
 
 func NewBinaryStore(c *config.JSONBinaryStoreConfig) *BinaryStore {
-	return &BinaryStore{config: *c}
+	return &BinaryStore{config: *c, store: *NewStore(&config.JSONStoreConfig{
+		Indent: c.Indent,
+	})}
 }
 
 // LoadEncryptedFile loads an encrypted json file onto a sops.Tree object

--- a/stores/json/store_test.go
+++ b/stores/json/store_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/getsops/sops/v3"
+	"github.com/getsops/sops/v3/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -408,4 +409,84 @@ func TestEmitValueString(t *testing.T) {
 	bytes, err := (&Store{}).EmitValue("hello")
 	assert.Nil(t, err)
 	assert.Equal(t, []byte("\"hello\""), bytes)
+}
+
+func TestIndentTwoSpaces(t *testing.T) {
+	tree := sops.Tree{
+		Branches: sops.TreeBranches{
+			sops.TreeBranch{
+				sops.TreeItem{
+					Key: "foo",
+					Value: []interface{}{
+						sops.TreeBranch{
+							sops.TreeItem{
+								Key:   "foo",
+								Value: 3,
+							},
+							sops.TreeItem{
+								Key:   "bar",
+								Value: false,
+							},
+						},
+						2,
+					},
+				},
+			},
+		},
+	}
+	expected := `{
+  "foo": [
+    {
+      "foo": 3,
+      "bar": false
+    },
+    2
+  ]
+}`
+	store := Store{
+		config: config.JSONStoreConfig{
+			Indent: 2,
+		},
+	}
+	out, err := store.EmitPlainFile(tree.Branches)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, string(out))
+}
+
+func TestIndentDefault(t *testing.T) {
+	tree := sops.Tree{
+		Branches: sops.TreeBranches{
+			sops.TreeBranch{
+				sops.TreeItem{
+					Key: "foo",
+					Value: []interface{}{
+						sops.TreeBranch{
+							sops.TreeItem{
+								Key:   "foo",
+								Value: 3,
+							},
+							sops.TreeItem{
+								Key:   "bar",
+								Value: false,
+							},
+						},
+						2,
+					},
+				},
+			},
+		},
+	}
+	expected := `{
+	"foo": [
+		{
+			"foo": 3,
+			"bar": false
+		},
+		2
+	]
+}`
+	store := Store{}
+	out, err := store.EmitPlainFile(tree.Branches)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, string(out))
 }

--- a/stores/json/store_test.go
+++ b/stores/json/store_test.go
@@ -313,7 +313,11 @@ func TestEncodeJSONArrayOfObjects(t *testing.T) {
 		2
 	]
 }`
-	store := Store{}
+	store := Store{
+		config: config.JSONStoreConfig{
+			Indent: -1,
+		},
+	}
 	out, err := store.EmitPlainFile(tree.Branches)
 	assert.Nil(t, err)
 	assert.Equal(t, expected, string(out))
@@ -485,7 +489,53 @@ func TestIndentDefault(t *testing.T) {
 		2
 	]
 }`
-	store := Store{}
+	store := Store{
+		config: config.JSONStoreConfig{
+			Indent: -1,
+		},
+	}
+	out, err := store.EmitPlainFile(tree.Branches)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, string(out))
+}
+
+func TestNoIndent(t *testing.T) {
+	tree := sops.Tree{
+		Branches: sops.TreeBranches{
+			sops.TreeBranch{
+				sops.TreeItem{
+					Key: "foo",
+					Value: []interface{}{
+						sops.TreeBranch{
+							sops.TreeItem{
+								Key:   "foo",
+								Value: 3,
+							},
+							sops.TreeItem{
+								Key:   "bar",
+								Value: false,
+							},
+						},
+						2,
+					},
+				},
+			},
+		},
+	}
+	expected := `{
+"foo": [
+{
+"foo": 3,
+"bar": false
+},
+2
+]
+}`
+	store := Store{
+		config: config.JSONStoreConfig{
+			Indent: 0,
+		},
+	}
 	out, err := store.EmitPlainFile(tree.Branches)
 	assert.Nil(t, err)
 	assert.Equal(t, expected, string(out))

--- a/stores/yaml/store.go
+++ b/stores/yaml/store.go
@@ -12,6 +12,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const IndentDefault = 4
+
 // Store handles storage of YAML data
 type Store struct {
 	config config.YAMLStoreConfig
@@ -329,7 +331,11 @@ func (store *Store) LoadPlainFile(in []byte) (sops.TreeBranches, error) {
 func (store *Store) EmitEncryptedFile(in sops.Tree) ([]byte, error) {
 	var b bytes.Buffer
 	e := yaml.NewEncoder(io.Writer(&b))
-	e.SetIndent(4)
+	indent := IndentDefault
+	if store.config.Indent != 0 {
+		indent = store.config.Indent
+	}
+	e.SetIndent(indent)
 	for _, branch := range in.Branches {
 		// Document root
 		var doc = yaml.Node{}
@@ -361,7 +367,11 @@ func (store *Store) EmitEncryptedFile(in sops.Tree) ([]byte, error) {
 func (store *Store) EmitPlainFile(branches sops.TreeBranches) ([]byte, error) {
 	var b bytes.Buffer
 	e := yaml.NewEncoder(io.Writer(&b))
-	e.SetIndent(4)
+	indent := IndentDefault
+	if store.config.Indent != 0 {
+		indent = store.config.Indent
+	}
+	e.SetIndent(indent)
 	for _, branch := range branches {
 		// Document root
 		var doc = yaml.Node{}

--- a/stores/yaml/store.go
+++ b/stores/yaml/store.go
@@ -407,6 +407,3 @@ func (store *Store) EmitExample() []byte {
 	}
 	return bytes
 }
-
-func (store *Store) Configure(c *config.Config) {
-}

--- a/stores/yaml/store.go
+++ b/stores/yaml/store.go
@@ -7,12 +7,18 @@ import (
 	"strings"
 
 	"github.com/getsops/sops/v3"
+	"github.com/getsops/sops/v3/config"
 	"github.com/getsops/sops/v3/stores"
 	"gopkg.in/yaml.v3"
 )
 
 // Store handles storage of YAML data
 type Store struct {
+	config config.YAMLStoreConfig
+}
+
+func NewStore(c *config.YAMLStoreConfig) *Store {
+	return &Store{config: *c}
 }
 
 func (store Store) appendCommentToList(comment string, list []interface{}) []interface{} {
@@ -390,4 +396,7 @@ func (store *Store) EmitExample() []byte {
 		panic(err)
 	}
 	return bytes
+}
+
+func (store *Store) Configure(c *config.Config) {
 }

--- a/stores/yaml/store.go
+++ b/stores/yaml/store.go
@@ -326,16 +326,19 @@ func (store *Store) LoadPlainFile(in []byte) (sops.TreeBranches, error) {
 	return branches, nil
 }
 
+func (store *Store) getIndentation() int {
+	if store.config.Indent != 0 {
+		return store.config.Indent
+	}
+	return IndentDefault
+}
+
 // EmitEncryptedFile returns the encrypted bytes of the yaml file corresponding to a
 // sops.Tree runtime object
 func (store *Store) EmitEncryptedFile(in sops.Tree) ([]byte, error) {
 	var b bytes.Buffer
 	e := yaml.NewEncoder(io.Writer(&b))
-	indent := IndentDefault
-	if store.config.Indent != 0 {
-		indent = store.config.Indent
-	}
-	e.SetIndent(indent)
+	e.SetIndent(store.getIndentation())
 	for _, branch := range in.Branches {
 		// Document root
 		var doc = yaml.Node{}
@@ -367,11 +370,7 @@ func (store *Store) EmitEncryptedFile(in sops.Tree) ([]byte, error) {
 func (store *Store) EmitPlainFile(branches sops.TreeBranches) ([]byte, error) {
 	var b bytes.Buffer
 	e := yaml.NewEncoder(io.Writer(&b))
-	indent := IndentDefault
-	if store.config.Indent != 0 {
-		indent = store.config.Indent
-	}
-	e.SetIndent(indent)
+	e.SetIndent(store.getIndentation())
 	for _, branch := range branches {
 		// Document root
 		var doc = yaml.Node{}


### PR DESCRIPTION
This PR aims to finish the work started in #930, thanks to @jamesgoodhouse.

I added the use of the Indent param in the store as well as a new `--indent` option in the cli. 
Let me know what you think about it.

Fixes #900, fixes #1048 and fixes #1028
