### PR TITLE
Enable Dependabot for Docker, GitHub Actions and Go Mod

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,41 @@
+version: 2
+
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    labels: ["dependencies"]
+    schedule:
+      # By default, this will be on a Monday.
+      interval: "weekly"
+    groups:
+      # Group all updates together, so that they are all applied in a single PR.
+      # xref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
+      docker:
+          patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels: ["area/CI", "dependencies"]
+    schedule:
+      # By default, this will be on a Monday.
+      interval: "weekly"
+    groups:
+      # Group all updates together, so that they are all applied in a single PR.
+      # xref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
+      ci:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    labels: ["dependencies"]
+    schedule:
+      # By default, this will be on a Monday.
+      interval: "weekly"
+    groups:
+      # Group all updates together, so that they are all applied in a single PR.
+      # xref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
+      go:
+        patterns:
+          - "*"


### PR DESCRIPTION
This enables Dependabot using two groups, one for GitHub Actions and one for Go Modules.

In the future, we may want to split the Go Modules into multiple groups. For example, one for each key source with a misc catch-all group for any other dependency.

xref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependency-updates#grouping-dependabot-version-updates-into-one-pull-request