### PR TITLE
release: generate versioned `.intoto.jsonl`

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,7 +11,7 @@ updates:
       # Group all updates together, so that they are all applied in a single PR.
       # xref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
       docker:
-          patterns:
+        patterns:
           - "*"
 
   - package-ecosystem: "github-actions"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
       packages: write # For pushing and signing container images.
 
     outputs:
+      version: "${{ steps.release-metadata.outputs.version }}"
       artifact-subjects: "${{ steps.artifact-hashes.outputs.subjects }}"
       package-subjects: "${{ steps.package-hashes.outputs.subjects }}"
       sbom-subjects: "${{ steps.sbom-hashes.outputs.subjects }}"
@@ -68,6 +69,14 @@ jobs:
           args: release --clean --timeout 1h
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract release metadata
+        id: release-metadata
+        env:
+          METADATA: "${{ steps.goreleaser.outputs.metadata }}"
+        run: |
+          set -euo pipefail
+          echo "version=$(echo -E $METADATA | jq -r '.version')" >> "$GITHUB_OUTPUT"
 
       - name: Extract artifact subjects
         id: artifact-hashes
@@ -149,7 +158,7 @@ jobs:
           echo "subjects=$(echo "$all_subjects" | base64 -w0)" >> "$GITHUB_OUTPUT"
 
   assets-provenance:
-    needs: [ combine-subjects ]
+    needs: [ release, combine-subjects ]
 
     permissions:
       actions: read # For detecting the GitHub Actions environment.
@@ -160,7 +169,7 @@ jobs:
     with:
       base64-subjects: "${{ needs.combine-subjects.outputs.all-subjects }}"
       upload-assets: true
-      provenance-name: "provenance.intoto.jsonl"
+      provenance-name: "sops-v${{ needs.release.outputs.version }}.intoto.jsonl"
 
   ghcr-container-provenance:
     needs: [ release ]

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -321,15 +321,15 @@ release:
 
     ### Verify artifact provenance
 
-    The [SLSA provenance](https://slsa.dev/provenance/v0.2) of the binaries, packages, and SBOMs can be found within the artifacts associated with this release. It is presented through an [in-toto](https://in-toto.io/) link metadata file named `provenance.intoto.jsonl`. To verify the provenance of an artifact, you can utilize the [`slsa-verifier`](https://github.com/slsa-framework/slsa-verifier#artifacts) tool:
+    The [SLSA provenance](https://slsa.dev/provenance/v0.2) of the binaries, packages, and SBOMs can be found within the artifacts associated with this release. It is presented through an [in-toto](https://in-toto.io/) link metadata file named `sops-v{{ .Version }}.intoto.jsonl`. To verify the provenance of an artifact, you can utilize the [`slsa-verifier`](https://github.com/slsa-framework/slsa-verifier#artifacts) tool:
 
     ```shell
     # Download the metadata file
-    curl -LO  https://github.com/{{ .Env.GITHUB_REPOSITORY }}/releases/download/{{ .Tag }}/provenance.intoto.jsonl
+    curl -LO  https://github.com/{{ .Env.GITHUB_REPOSITORY }}/releases/download/{{ .Tag }}/sops-v{{ .Version }}.intoto.jsonl
 
     # Verify the provenance of the artifact
     slsa-verifier verify-artifact <artifact> \
-      --provenance-path provenance.intoto.jsonl \
+      --provenance-path sops-v{{ .Version }}.intoto.jsonl \
       --source-uri github.com/{{ .Env.GITHUB_REPOSITORY }} \
       --source-tag {{ .Tag }}
     ```


### PR DESCRIPTION
This ensures the file name is unique per release, and can be linked by file name to the specific SOPS version it is targeted at.

Based on comment in https://github.com/getsops/sops/issues/1266#issuecomment-1701880681.