### PR TITLE
keyservices: address logging regression

### DIFF
--- a/age/keysource.go
+++ b/age/keysource.go
@@ -11,8 +11,8 @@ import (
 
 	"filippo.io/age"
 	"filippo.io/age/armor"
-	"github.com/sirupsen/logrus"
 	"github.com/getsops/sops/v3/logging"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -124,7 +124,7 @@ func (key *MasterKey) Encrypt(dataKey []byte) error {
 	if key.parsedRecipient == nil {
 		parsedRecipient, err := parseRecipient(key.Recipient)
 		if err != nil {
-			log.WithField("recipient", key.parsedRecipient).Error("Encryption failed")
+			log.WithField("recipient", key.parsedRecipient).Info("Encryption failed")
 			return err
 		}
 		key.parsedRecipient = parsedRecipient
@@ -134,19 +134,19 @@ func (key *MasterKey) Encrypt(dataKey []byte) error {
 	aw := armor.NewWriter(&buffer)
 	w, err := age.Encrypt(aw, key.parsedRecipient)
 	if err != nil {
-		log.WithField("recipient", key.parsedRecipient).Error("Encryption failed")
+		log.WithField("recipient", key.parsedRecipient).Info("Encryption failed")
 		return fmt.Errorf("failed to create writer for encrypting sops data key with age: %w", err)
 	}
 	if _, err := w.Write(dataKey); err != nil {
-		log.WithField("recipient", key.parsedRecipient).Error("Encryption failed")
+		log.WithField("recipient", key.parsedRecipient).Info("Encryption failed")
 		return fmt.Errorf("failed to encrypt sops data key with age: %w", err)
 	}
 	if err := w.Close(); err != nil {
-		log.WithField("recipient", key.parsedRecipient).Error("Encryption failed")
+		log.WithField("recipient", key.parsedRecipient).Info("Encryption failed")
 		return fmt.Errorf("failed to close writer for encrypting sops data key with age: %w", err)
 	}
 	if err := aw.Close(); err != nil {
-		log.WithField("recipient", key.parsedRecipient).Error("Encryption failed")
+		log.WithField("recipient", key.parsedRecipient).Info("Encryption failed")
 		return fmt.Errorf("failed to close armored writer: %w", err)
 	}
 
@@ -180,7 +180,7 @@ func (key *MasterKey) Decrypt() ([]byte, error) {
 	if len(key.parsedIdentities) == 0 {
 		ids, err := key.loadIdentities()
 		if err != nil {
-			log.Error("Decryption failed")
+			log.Info("Decryption failed")
 			return nil, fmt.Errorf("failed to load age identities: %w", err)
 		}
 		ids.ApplyToMasterKey(key)
@@ -190,13 +190,13 @@ func (key *MasterKey) Decrypt() ([]byte, error) {
 	ar := armor.NewReader(src)
 	r, err := age.Decrypt(ar, key.parsedIdentities...)
 	if err != nil {
-		log.Error("Decryption failed")
+		log.Info("Decryption failed")
 		return nil, fmt.Errorf("failed to create reader for decrypting sops data key with age: %w", err)
 	}
 
 	var b bytes.Buffer
 	if _, err := io.Copy(&b, r); err != nil {
-		log.Error("Decryption failed")
+		log.Info("Decryption failed")
 		return nil, fmt.Errorf("failed to copy age decrypted data into bytes.Buffer: %w", err)
 	}
 

--- a/azkv/keysource.go
+++ b/azkv/keysource.go
@@ -117,13 +117,13 @@ func (t TokenCredential) ApplyToMasterKey(key *MasterKey) {
 func (key *MasterKey) Encrypt(dataKey []byte) error {
 	token, err := key.getTokenCredential()
 	if err != nil {
-		log.WithFields(logrus.Fields{"key": key.Name, "version": key.Version}).Error("Encryption failed")
+		log.WithFields(logrus.Fields{"key": key.Name, "version": key.Version}).Info("Encryption failed")
 		return fmt.Errorf("failed to get Azure token credential to encrypt data: %w", err)
 	}
 
 	c, err := azkeys.NewClient(key.VaultURL, token, nil)
 	if err != nil {
-		log.WithFields(logrus.Fields{"key": key.Name, "version": key.Version}).Error("Encryption failed")
+		log.WithFields(logrus.Fields{"key": key.Name, "version": key.Version}).Info("Encryption failed")
 		return fmt.Errorf("failed to construct Azure Key Vault client to encrypt data: %w", err)
 	}
 
@@ -132,7 +132,7 @@ func (key *MasterKey) Encrypt(dataKey []byte) error {
 		Value:     dataKey,
 	}, nil)
 	if err != nil {
-		log.WithFields(logrus.Fields{"key": key.Name, "version": key.Version}).Error("Encryption failed")
+		log.WithFields(logrus.Fields{"key": key.Name, "version": key.Version}).Info("Encryption failed")
 		return fmt.Errorf("failed to encrypt sops data key with Azure Key Vault key '%s': %w", key.ToString(), err)
 	}
 
@@ -166,19 +166,19 @@ func (key *MasterKey) EncryptIfNeeded(dataKey []byte) error {
 func (key *MasterKey) Decrypt() ([]byte, error) {
 	token, err := key.getTokenCredential()
 	if err != nil {
-		log.WithFields(logrus.Fields{"key": key.Name, "version": key.Version}).Error("Decryption failed")
+		log.WithFields(logrus.Fields{"key": key.Name, "version": key.Version}).Info("Decryption failed")
 		return nil, fmt.Errorf("failed to get Azure token credential to decrypt: %w", err)
 	}
 
 	rawEncryptedKey, err := base64.RawURLEncoding.DecodeString(key.EncryptedKey)
 	if err != nil {
-		log.WithFields(logrus.Fields{"key": key.Name, "version": key.Version}).Error("Decryption failed")
+		log.WithFields(logrus.Fields{"key": key.Name, "version": key.Version}).Info("Decryption failed")
 		return nil, fmt.Errorf("failed to base64 decode Azure Key Vault encrypted key: %w", err)
 	}
 
 	c, err := azkeys.NewClient(key.VaultURL, token, nil)
 	if err != nil {
-		log.WithFields(logrus.Fields{"key": key.Name, "version": key.Version}).Error("Decryption failed")
+		log.WithFields(logrus.Fields{"key": key.Name, "version": key.Version}).Info("Decryption failed")
 		return nil, fmt.Errorf("failed to construct Azure Key Vault client to decrypt data: %w", err)
 	}
 
@@ -187,7 +187,7 @@ func (key *MasterKey) Decrypt() ([]byte, error) {
 		Value:     rawEncryptedKey,
 	}, nil)
 	if err != nil {
-		log.WithFields(logrus.Fields{"key": key.Name, "version": key.Version}).Error("Decryption failed")
+		log.WithFields(logrus.Fields{"key": key.Name, "version": key.Version}).Info("Decryption failed")
 		return nil, fmt.Errorf("failed to decrypt sops data key with Azure Key Vault key '%s': %w", key.ToString(), err)
 	}
 	log.WithFields(logrus.Fields{"key": key.Name, "version": key.Version}).Info("Decryption succeeded")

--- a/gcpkms/keysource.go
+++ b/gcpkms/keysource.go
@@ -94,7 +94,7 @@ func (c CredentialJSON) ApplyToMasterKey(key *MasterKey) {
 func (key *MasterKey) Encrypt(dataKey []byte) error {
 	service, err := key.newKMSClient()
 	if err != nil {
-		log.WithField("resourceID", key.ResourceID).Error("Encryption failed")
+		log.WithField("resourceID", key.ResourceID).Info("Encryption failed")
 		return fmt.Errorf("cannot create GCP KMS service: %w", err)
 	}
 	defer func() {
@@ -110,7 +110,7 @@ func (key *MasterKey) Encrypt(dataKey []byte) error {
 	ctx := context.Background()
 	resp, err := service.Encrypt(ctx, req)
 	if err != nil {
-		log.WithField("resourceID", key.ResourceID).Error("Encryption failed")
+		log.WithField("resourceID", key.ResourceID).Info("Encryption failed")
 		return fmt.Errorf("failed to encrypt sops data key with GCP KMS key: %w", err)
 	}
 	// NB: base64 encoding is for compatibility with SOPS <=3.8.x.
@@ -145,7 +145,7 @@ func (key *MasterKey) EncryptIfNeeded(dataKey []byte) error {
 func (key *MasterKey) Decrypt() ([]byte, error) {
 	service, err := key.newKMSClient()
 	if err != nil {
-		log.WithField("resourceID", key.ResourceID).Error("Decryption failed")
+		log.WithField("resourceID", key.ResourceID).Info("Decryption failed")
 		return nil, fmt.Errorf("cannot create GCP KMS service: %w", err)
 	}
 	defer func() {
@@ -158,7 +158,7 @@ func (key *MasterKey) Decrypt() ([]byte, error) {
 	// client used to work with base64 encoded strings.
 	decodedCipher, err := base64.StdEncoding.DecodeString(string(key.EncryptedDataKey()))
 	if err != nil {
-		log.WithField("resourceID", key.ResourceID).Error("Decryption failed")
+		log.WithField("resourceID", key.ResourceID).Info("Decryption failed")
 		return nil, err
 	}
 
@@ -169,7 +169,7 @@ func (key *MasterKey) Decrypt() ([]byte, error) {
 	ctx := context.Background()
 	resp, err := service.Decrypt(ctx, req)
 	if err != nil {
-		log.WithField("resourceID", key.ResourceID).Error("Decryption failed")
+		log.WithField("resourceID", key.ResourceID).Info("Decryption failed")
 		return nil, fmt.Errorf("failed to decrypt sops data key with GCP KMS key: %w", err)
 	}
 

--- a/hcvault/keysource.go
+++ b/hcvault/keysource.go
@@ -130,18 +130,18 @@ func (key *MasterKey) Encrypt(dataKey []byte) error {
 
 	client, err := vaultClient(key.VaultAddress, key.token)
 	if err != nil {
-		log.WithField("Path", fullPath).Error("Encryption failed")
+		log.WithField("Path", fullPath).Info("Encryption failed")
 		return err
 	}
 
 	secret, err := client.Logical().Write(fullPath, encryptPayload(dataKey))
 	if err != nil {
-		log.WithField("Path", fullPath).Error("Encryption failed")
+		log.WithField("Path", fullPath).Info("Encryption failed")
 		return fmt.Errorf("failed to encrypt sops data key to Vault transit backend '%s': %w", fullPath, err)
 	}
 	encryptedKey, err := encryptedKeyFromSecret(secret)
 	if err != nil {
-		log.WithField("Path", fullPath).Error("Encryption failed")
+		log.WithField("Path", fullPath).Info("Encryption failed")
 		return fmt.Errorf("failed to encrypt sops data key to Vault transit backend '%s': %w", fullPath, err)
 	}
 
@@ -175,18 +175,18 @@ func (key *MasterKey) Decrypt() ([]byte, error) {
 
 	client, err := vaultClient(key.VaultAddress, key.token)
 	if err != nil {
-		log.WithField("Path", fullPath).Error("Decryption failed")
+		log.WithField("Path", fullPath).Info("Decryption failed")
 		return nil, err
 	}
 
 	secret, err := client.Logical().Write(fullPath, decryptPayload(key.EncryptedKey))
 	if err != nil {
-		log.WithField("Path", fullPath).Error("Decryption failed")
+		log.WithField("Path", fullPath).Info("Decryption failed")
 		return nil, fmt.Errorf("failed to decrypt sops data key from Vault transit backend '%s': %w", fullPath, err)
 	}
 	dataKey, err := dataKeyFromSecret(secret)
 	if err != nil {
-		log.WithField("Path", fullPath).Error("Decryption failed")
+		log.WithField("Path", fullPath).Info("Decryption failed")
 		return nil, fmt.Errorf("failed to decrypt sops data key from Vault transit backend '%s': %w", fullPath, err)
 	}
 

--- a/kms/keysource.go
+++ b/kms/keysource.go
@@ -194,7 +194,7 @@ func (c CredentialsProvider) ApplyToMasterKey(key *MasterKey) {
 func (key *MasterKey) Encrypt(dataKey []byte) error {
 	cfg, err := key.createKMSConfig()
 	if err != nil {
-		log.WithField("arn", key.Arn).Error("Encryption failed")
+		log.WithField("arn", key.Arn).Info("Encryption failed")
 		return err
 	}
 	client := key.createClient(cfg)
@@ -205,7 +205,7 @@ func (key *MasterKey) Encrypt(dataKey []byte) error {
 	}
 	out, err := client.Encrypt(context.TODO(), input)
 	if err != nil {
-		log.WithField("arn", key.Arn).Error("Encryption failed")
+		log.WithField("arn", key.Arn).Info("Encryption failed")
 		return fmt.Errorf("failed to encrypt sops data key with AWS KMS: %w", err)
 	}
 	key.EncryptedKey = base64.StdEncoding.EncodeToString(out.CiphertextBlob)
@@ -237,12 +237,12 @@ func (key *MasterKey) SetEncryptedDataKey(enc []byte) {
 func (key *MasterKey) Decrypt() ([]byte, error) {
 	k, err := base64.StdEncoding.DecodeString(key.EncryptedKey)
 	if err != nil {
-		log.WithField("arn", key.Arn).Error("Decryption failed")
+		log.WithField("arn", key.Arn).Info("Decryption failed")
 		return nil, fmt.Errorf("error base64-decoding encrypted data key: %s", err)
 	}
 	cfg, err := key.createKMSConfig()
 	if err != nil {
-		log.WithField("arn", key.Arn).Error("Decryption failed")
+		log.WithField("arn", key.Arn).Info("Decryption failed")
 		return nil, err
 	}
 	client := key.createClient(cfg)
@@ -253,7 +253,7 @@ func (key *MasterKey) Decrypt() ([]byte, error) {
 	}
 	decrypted, err := client.Decrypt(context.TODO(), input)
 	if err != nil {
-		log.WithField("arn", key.Arn).Error("Decryption failed")
+		log.WithField("arn", key.Arn).Info("Decryption failed")
 		return nil, fmt.Errorf("failed to decrypt sops data key with AWS KMS: %w", err)
 	}
 	log.WithField("arn", key.Arn).Info("Decryption succeeded")

--- a/pgp/keysource.go
+++ b/pgp/keysource.go
@@ -257,7 +257,7 @@ func (key *MasterKey) Encrypt(dataKey []byte) error {
 	}
 	errs = append(errs, fmt.Errorf("GnuPG binary error: %w", binaryErr))
 
-	log.WithField("fingerprint", key.Fingerprint).Error("Encryption failed")
+	log.WithField("fingerprint", key.Fingerprint).Info("Encryption failed")
 	return fmt.Errorf("could not encrypt data key with PGP key: %w", errs)
 }
 
@@ -368,7 +368,7 @@ func (key *MasterKey) Decrypt() ([]byte, error) {
 	}
 	errs = append(errs, fmt.Errorf("GnuPG binary error: %w", binaryErr))
 
-	log.WithField("fingerprint", key.Fingerprint).Error("Decryption failed")
+	log.WithField("fingerprint", key.Fingerprint).Info("Decryption failed")
 	return nil, fmt.Errorf("could not decrypt data key with PGP key: %w", errs)
 }
 


### PR DESCRIPTION
Replace the logging of failed encryption and decryption attempts from
error to info level.

This to address a regression in which an encryption or decryption
attempt with a series of keys would result in a list of failed attempts
logged to stderr even when the operation itself eventually succeeded.

xref: https://github.com/getsops/sops/discussions/1270#discussioncomment-6883254