### PR TITLE
pgp: remove `DisableAgent` option

### DIFF
--- a/pgp/keysource_test.go
+++ b/pgp/keysource_test.go
@@ -148,12 +148,6 @@ func TestGnuPGHome_ApplyToMasterKey(t *testing.T) {
 	assert.NotEqual(t, gnuPGHome.String(), key.gnuPGHomeDir)
 }
 
-func TestDisableAgent_ApplyToMasterKey(t *testing.T) {
-	key := NewMasterKeyFromFingerprint(mockFingerprint)
-	DisableAgent{}.ApplyToMasterKey(key)
-	assert.True(t, key.disableAgent)
-}
-
 func TestDisableOpenPGP_ApplyToMasterKey(t *testing.T) {
 	key := NewMasterKeyFromFingerprint(mockFingerprint)
 	DisableOpenPGP{}.ApplyToMasterKey(key)


### PR DESCRIPTION
This option actually gives a false impression, as disabling the agent is no longer possible since GnuPG 2.x.

```
--use-agent --no-use-agent This is dummy option. gpg always requires the agent.
```

xref: https://www.gnupg.org/documentation/manuals/gnupg24/gpg.1.html