### PR TITLE
Better error reporting for missing gpg binary

### DIFF
--- a/pgp/keysource.go
+++ b/pgp/keysource.go
@@ -132,17 +132,17 @@ func (d GnuPGHome) Import(armoredKey []byte) error {
 	}
 
 	args := []string{"--batch", "--import"}
-	_, stderrBuf, err := gpgExec(d.String(), args, bytes.NewReader(armoredKey))
+	_, stderr, err := gpgExec(d.String(), args, bytes.NewReader(armoredKey))
 	if err != nil {
-		stderr := stderrBuf.String()
+		stderrStr := strings.TrimSpace(stderr.String())
 		errStr := err.Error()
 		var sb strings.Builder
 		sb.WriteString("failed to import armored key data into GnuPG keyring")
-		if len(stderr) > 0 {
-			fmt.Fprintf(&sb, ": %s", stderr)
+		if len(stderrStr) > 0 {
 			if len(errStr) > 0 {
-				fmt.Fprintf(&sb, ": %s", errStr)
+				fmt.Fprintf(&sb, " (%s)", errStr)
 			}
+			fmt.Fprintf(&sb, ": %s", stderrStr)
 		} else if len(errStr) > 0 {
 			fmt.Fprintf(&sb, ": %s", errStr)
 		}

--- a/pgp/keysource_test.go
+++ b/pgp/keysource_test.go
@@ -68,7 +68,7 @@ func TestGnuPGHome_Import(t *testing.T) {
 
 	err = gnuPGHome.Import([]byte("invalid armored data"))
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "gpg: no valid OpenPGP data found.\ngpg: Total number processed: 0\n: exit status 2")
+	assert.ErrorContains(t, err, "(exit status 2): gpg: no valid OpenPGP data found.\ngpg: Total number processed: 0")
 	assert.Error(t, GnuPGHome("").Import(b))
 }
 


### PR DESCRIPTION
The error returned by `gpgExec` has just been swallowed. Now it is stringified and returned together with any output to stderr.