### PR TITLE
Do not crash if an empty YAML file is encrypted

### DIFF
--- a/cmd/sops/codes/codes.go
+++ b/cmd/sops/codes/codes.go
@@ -21,6 +21,7 @@ const (
 	ConfigFileNotFound                     int = 61
 	KeyboardInterrupt                      int = 85
 	InvalidTreePathFormat                  int = 91
+	NeedAtLeastOneDocument                 int = 92
 	NoFileSpecified                        int = 100
 	CouldNotRetrieveKey                    int = 128
 	NoEncryptionKeyFound                   int = 111

--- a/cmd/sops/encrypt.go
+++ b/cmd/sops/encrypt.go
@@ -64,6 +64,9 @@ func encrypt(opts encryptOpts) (encryptedFile []byte, err error) {
 	if err != nil {
 		return nil, common.NewExitError(fmt.Sprintf("Error unmarshalling file: %s", err), codes.CouldNotReadInputFile)
 	}
+	if len(branches) < 1 {
+		return nil, common.NewExitError("File cannot be completely empty, it must contain at least one document", codes.NeedAtLeastOneDocument)
+	}
 	if err := ensureNoMetadata(opts, branches[0]); err != nil {
 		return nil, common.NewExitError(err, codes.FileAlreadyEncrypted)
 	}


### PR DESCRIPTION
An empty YAML file results in no tree branch, which trips over encrypt since it assumes there's at least one.

I'm not sure this is the correct way to fix this, since the encrypted result will be empty as well (zero tree branches).

On the other hand, if you encrypt a YAML file with `{}` or `---` in it (and nothing else), there will be at least one tree branch. Decrypting the resulting file yields `{}`. Decrypting an empty file yields an `sops metadata not found` error.