### PR TITLE
pgp: do not require abs path for SopsGpgExecEnv 

### DIFF
--- a/pgp/keysource.go
+++ b/pgp/keysource.go
@@ -578,14 +578,13 @@ func gpgExec(homeDir string, args []string, stdin io.Reader) (stdout bytes.Buffe
 }
 
 // gpgBinary returns the GnuPG binary which must be used.
-// It allows for runtime modifications by setting the environment variable
-// SopsGpgExecEnv to the absolute path of the replacement binary.
+// It allows for runtime modifications by setting the replacement binary
+// via the environment variable SopsGpgExecEnv.
 func gpgBinary() string {
-	binary := "gpg"
-	if envBinary := os.Getenv(SopsGpgExecEnv); envBinary != "" && filepath.IsAbs(envBinary) {
-		binary = envBinary
+	if envBinary := os.Getenv(SopsGpgExecEnv); envBinary != "" {
+		return envBinary
 	}
-	return binary
+	return "gpg"
 }
 
 // gnuPGHome determines the GnuPG home directory, and returns its path.

--- a/pgp/keysource_test.go
+++ b/pgp/keysource_test.go
@@ -651,6 +651,10 @@ func Test_gpgBinary(t *testing.T) {
 	overwrite := "/some/other/gpg"
 	t.Setenv(SopsGpgExecEnv, overwrite)
 	assert.Equal(t, overwrite, gpgBinary())
+
+	overwrite = "not_abs_path"
+	t.Setenv(SopsGpgExecEnv, overwrite)
+	assert.Equal(t, overwrite, gpgBinary())
 }
 
 func Test_gnuPGHome(t *testing.T) {


### PR DESCRIPTION
I was using `sops` on a qubes machine, with a separate `vault` vm holding the keys. In order to get this to work with sops, the environment override is required. It tripped me up a bit why it didn't accept my override, so this PR adds a warning when an environment override is detected but ignored. 

Successful usage: 
```
$ SOPS_GPG_EXEC=`which qubes-gpg-client-wrapper` go run ./cmd/sops/ --decrypt <my_file>
(works)
```
How it looks during failure:
```
$ SOPS_GPG_EXEC="qubes-gpg-client-wrapper" go run ./cmd/sops/ --decrypt >my_file>
[PGP]    WARN[0000] Environment SOPS_GPG_EXEC was set, but not an absolute path and therefore ignored.  SOPS_GPG_EXEC=qubes-gpg-client-wrapper
[PGP]    WARN[0000] Environment SOPS_GPG_EXEC was set, but not an absolute path and therefore ignored.  SOPS_GPG_EXEC=qubes-gpg-client-wrapper
[PGP]    WARN[0000] Environment SOPS_GPG_EXEC was set, but not an absolute path and therefore ignored.  SOPS_GPG_EXEC=qubes-gpg-client-wrapper
[PGP]    WARN[0000] Environment SOPS_GPG_EXEC was set, but not an absolute path and therefore ignored.  SOPS_GPG_EXEC=qubes-gpg-client-wrapper
[PGP]    WARN[0000] Environment SOPS_GPG_EXEC was set, but not an absolute path and therefore ignored.  SOPS_GPG_EXEC=qubes-gpg-client-wrapper
[PGP]    WARN[0000] Environment SOPS_GPG_EXEC was set, but not an absolute path and therefore ignored.  SOPS_GPG_EXEC=qubes-gpg-client-wrapper
Failed to get the data key required to decrypt the SOPS file.

Group 0: FAILED
```

----

Tangentially, I'm not sure why there's a requirement for absolute path. When doing the same thing with `git`, the following suffices to use in `~/.gitconfig`: 
```
[gpg]
        program = qubes-gpg-client-wrapper
```
