### PR TITLE
pgp: fix dropped test errors

### DIFF
--- a/pgp/keysource_test.go
+++ b/pgp/keysource_test.go
@@ -332,6 +332,7 @@ func TestMasterKey_Decrypt(t *testing.T) {
 		fingerprint,
 		"--no-encrypt-to",
 	}, bytes.NewReader(data))
+	assert.NoError(t, err)
 	assert.NoErrorf(t, gnuPGHome.ImportFile(mockPrivateKey), stderr.String())
 
 	encryptedData := stdout.String()
@@ -414,6 +415,7 @@ func TestMasterKey_decryptWithOpenPGP(t *testing.T) {
 			fingerprint,
 			"--no-encrypt-to",
 		}, bytes.NewReader(data))
+		assert.NoError(t, err)
 		assert.NoErrorf(t, gnuPGHome.ImportFile(mockPrivateKey), stderr.String())
 
 		encryptedData := stdout.String()
@@ -462,6 +464,7 @@ func TestMasterKey_decryptWithGnuPG(t *testing.T) {
 			fingerprint,
 			"--no-encrypt-to",
 		}, bytes.NewReader(data))
+		assert.NoError(t, err)
 		assert.NoErrorf(t, gnuPGHome.ImportFile(mockPrivateKey), stderr.String())
 
 		encryptedData := stdout.String()


### PR DESCRIPTION
This fixes three dropped `err` variables in the tests for `pgp`. I imported the sops functional test keys to verify that the tests were unaffected.