### PR TITLE
Polish the 'sops help' output a bit

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -71,7 +71,8 @@ func main() {
 		{Name: "Adrian Utrilla", Email: "adrianutrilla@gmail.com"},
 		{Name: "Julien Vehent", Email: "jvehent@mozilla.com"},
 	}
-	app.UsageText = `sops is an editor of encrypted files that supports AWS KMS and PGP
+	app.UsageText = `sops is an editor of encrypted files that supports AWS KMS, GCP, AZKV,
+	PGP, and Age
 
    To encrypt or decrypt a document with AWS KMS, specify the KMS ARN
    in the -k flag or in the SOPS_KMS_ARN environment variable.
@@ -80,26 +81,28 @@ func main() {
    To encrypt or decrypt a document with GCP KMS, specify the
    GCP KMS resource ID in the --gcp-kms flag or in the SOPS_GCP_KMS_IDS
    environment variable.
-   (you need to setup google application default credentials. See
+   (You need to setup Google application default credentials. See
     https://developers.google.com/identity/protocols/application-default-credentials)
 
 
-   To encrypt or decrypt a document with HashiCorp Vault's Transit Secret Engine, specify the
-   Vault key URI name in the --hc-vault-transit flag or in the SOPS_VAULT_URIS environment variable (eg. https://vault.example.org:8200/v1/transit/keys/dev
-      where 'https://vault.example.org:8200' is the vault server, 'transit' the enginePath, and 'dev' is the name of the key )
-   environment variable.
-   (you need to enable the Transit Secrets Engine in Vault. See
-      https://www.vaultproject.io/docs/secrets/transit/index.html)
+   To encrypt or decrypt a document with HashiCorp Vault's Transit Secret
+   Engine, specify the Vault key URI name in the --hc-vault-transit flag
+   or in the SOPS_VAULT_URIS environment variable (for example
+   https://vault.example.org:8200/v1/transit/keys/dev, where
+   'https://vault.example.org:8200' is the vault server, 'transit' the
+   enginePath, and 'dev' is the name of the key).
+   (You need to enable the Transit Secrets Engine in Vault. See
+    https://www.vaultproject.io/docs/secrets/transit/index.html)
 
    To encrypt or decrypt a document with Azure Key Vault, specify the
-   Azure Key Vault key URL in the --azure-kv flag or in the SOPS_AZURE_KEYVAULT_URL
-   environment variable.
-   (authentication is based on environment variables, see
+   Azure Key Vault key URL in the --azure-kv flag or in the
+   SOPS_AZURE_KEYVAULT_URL environment variable.
+   (Authentication is based on environment variables, see
     https://docs.microsoft.com/en-us/go/azure/azure-sdk-go-authorization#use-environment-based-authentication.
-    The user/sp needs the key/encrypt and key/decrypt permissions)
+    The user/sp needs the key/encrypt and key/decrypt permissions.)
 
-   To encrypt or decrypt using age, specify the recipient in the -a flag, or
-   in the SOPS_AGE_RECIPIENTS environment variable.
+   To encrypt or decrypt using age, specify the recipient in the -a flag,
+   or in the SOPS_AGE_RECIPIENTS environment variable.
 
    To encrypt or decrypt using PGP, specify the PGP fingerprint in the
    -p flag or in the SOPS_PGP_FP environment variable.
@@ -107,17 +110,22 @@ func main() {
    To use multiple KMS or PGP keys, separate them by commas. For example:
        $ sops -p "10F2...0A, 85D...B3F21" file.yaml
 
-   The -p, -k, --gcp-kms, --hc-vault-transit and --azure-kv flags are only used to encrypt new documents. Editing
-   or decrypting existing documents can be done with "sops file" or
-   "sops -d file" respectively. The KMS and PGP keys listed in the encrypted
-   documents are used then. To manage master keys in existing documents, use
-   the "add-{kms,pgp,gcp-kms,azure-kv,hc-vault-transit}" and "rm-{kms,pgp,gcp-kms,azure-kv,hc-vault-transit}" flags.
+   The -p, -k, --gcp-kms, --hc-vault-transit, and --azure-kv flags are only
+   used to encrypt new documents. Editing or decrypting existing documents
+   can be done with "sops file" or "sops -d file" respectively. The KMS and
+   PGP keys listed in the encrypted documents are used then. To manage master
+   keys in existing documents, use the "add-{kms,pgp,gcp-kms,azure-kv,hc-vault-transit}"
+   and "rm-{kms,pgp,gcp-kms,azure-kv,hc-vault-transit}" flags with --rotate
+   or the updatekeys command.
 
    To use a different GPG binary than the one in your PATH, set SOPS_GPG_EXEC.
 
    To select a different editor than the default (vim), set EDITOR.
 
-   For more information, see the README at github.com/mozilla/sops`
+   Note that flags must always be provided before the filename to operate on.
+   Otherwise, they will be ignored.
+
+   For more information, see the README at https://github.com/getsops/sops`
 	app.EnableBashCompletion = true
 	app.Commands = []cli.Command{
 		{


### PR DESCRIPTION
In particular re-adjust line lengths.

Also mention that flags should always come before filenames.