### PR TITLE
Warn/fail if the wrong number of arguments is provided

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -58,7 +58,7 @@ func warnMoreThanOnePositionalArgument(c *cli.Context) {
 			}
 		}
 		if potentialFlag != "" {
-			log.Warn(fmt.Sprintf("Note that one of the ignored positional argument is %q, which looks like a flag. Flags must always be provied before the first positional argument!", potentialFlag))
+			log.Warn(fmt.Sprintf("Note that one of the ignored positional argument is %q, which looks like a flag. Flags must always be provided before the first positional argument!", potentialFlag))
 		}
 	}
 }


### PR DESCRIPTION
When warning, also inform about potentially ignored flags.

This improves UX because right now, many users find out that some of their flags are "ignored" (because the CLI library treats them as positional arguments, and sops only uses the first one of them). See for example #1259 or #598.

Either #1274 or this PR needs to be adjusted, whatever is merged first, since this PR is adding a warning for `updatekeys`, while that PR allows `updatekeys` to process multiple filenames.