### PR TITLE
Sort masterkeys according to decryption-order

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -170,6 +170,11 @@ Given that, the only command a SOPS user needs is:
 encrypted if modified, and saved back to its original location. All of these
 steps, apart from the actual editing, are transparent to the user.
 
+The order in which available decryption methods are tried can be specified with
+``--decryption-order`` option or **SOPS_DECRYPTION_ORDER** environment variable
+as a comma separated list. The default order is ``age,pgp``. Offline methods are
+tried first and then the remaining ones.
+
 Test with the dev PGP key
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/age/keysource.go
+++ b/age/keysource.go
@@ -12,8 +12,9 @@ import (
 
 	"filippo.io/age"
 	"filippo.io/age/armor"
-	"github.com/getsops/sops/v3/logging"
 	"github.com/sirupsen/logrus"
+
+	"github.com/getsops/sops/v3/logging"
 )
 
 const (
@@ -28,6 +29,8 @@ const (
 	SopsAgeKeyUserConfigPath = "sops/age/keys.txt"
 	// On macOS, os.UserConfigDir() ignores XDG_CONFIG_HOME. So we handle that manually.
 	xdgConfigHome = "XDG_CONFIG_HOME"
+	// KeyTypeIdentifier is the string used to identify an age MasterKey.
+	KeyTypeIdentifier = "age"
 )
 
 // log is the global logger for any age MasterKey.
@@ -223,6 +226,11 @@ func (key *MasterKey) ToMap() map[string]interface{} {
 	out["recipient"] = key.Recipient
 	out["enc"] = key.EncryptedKey
 	return out
+}
+
+// TypeToIdentifier returns the string identifier for the MasterKey type.
+func (key *MasterKey) TypeToIdentifier() string {
+	return KeyTypeIdentifier
 }
 
 func getUserConfigDir() (string, error) {

--- a/azkv/keysource.go
+++ b/azkv/keysource.go
@@ -22,6 +22,11 @@ import (
 	"github.com/getsops/sops/v3/logging"
 )
 
+const (
+	// KeyTypeIdentifier is the string used to identify an Azure Key Vault MasterKey.
+	KeyTypeIdentifier = "azure_kv"
+)
+
 var (
 	// log is the global logger for any Azure Key Vault MasterKey.
 	log *logrus.Logger
@@ -213,6 +218,11 @@ func (key MasterKey) ToMap() map[string]interface{} {
 	out["created_at"] = key.CreationDate.UTC().Format(time.RFC3339)
 	out["enc"] = key.EncryptedKey
 	return out
+}
+
+// TypeToIdentifier returns the string identifier for the MasterKey type.
+func (key *MasterKey) TypeToIdentifier() string {
+	return KeyTypeIdentifier
 }
 
 // getTokenCredential returns the tokenCredential of the MasterKey, or

--- a/cmd/sops/codes/codes.go
+++ b/cmd/sops/codes/codes.go
@@ -25,6 +25,7 @@ const (
 	NoFileSpecified                        int = 100
 	CouldNotRetrieveKey                    int = 128
 	NoEncryptionKeyFound                   int = 111
+	DuplicateDecryptionKeyType             int = 112
 	FileHasNotBeenModified                 int = 200
 	NoEditorFound                          int = 201
 	FailedToCompareVersions                int = 202

--- a/cmd/sops/common/common.go
+++ b/cmd/sops/common/common.go
@@ -72,6 +72,8 @@ type DecryptTreeOpts struct {
 	Tree *sops.Tree
 	// KeyServices are the key services to be used for decryption of the data key
 	KeyServices []keyservice.KeyServiceClient
+	// DecryptionOrder is the order in which available decryption methods are tried
+	DecryptionOrder []string
 	// IgnoreMac is whether or not to ignore the Message Authentication Code included in the SOPS tree
 	IgnoreMac bool
 	// Cipher is the cryptographic cipher to use to decrypt the values inside the tree
@@ -80,7 +82,7 @@ type DecryptTreeOpts struct {
 
 // DecryptTree decrypts the tree passed in through the DecryptTreeOpts and additionally returns the decrypted data key
 func DecryptTree(opts DecryptTreeOpts) (dataKey []byte, err error) {
-	dataKey, err = opts.Tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices)
+	dataKey, err = opts.Tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices, opts.DecryptionOrder)
 	if err != nil {
 		return nil, NewExitError(err, codes.CouldNotRetrieveKey)
 	}
@@ -222,11 +224,12 @@ func GetKMSKeyWithEncryptionCtx(tree *sops.Tree) (keyGroupIndex int, keyIndex in
 
 // GenericDecryptOpts represents decryption options and config
 type GenericDecryptOpts struct {
-	Cipher      sops.Cipher
-	InputStore  sops.Store
-	InputPath   string
-	IgnoreMAC   bool
-	KeyServices []keyservice.KeyServiceClient
+	Cipher          sops.Cipher
+	InputStore      sops.Store
+	InputPath       string
+	IgnoreMAC       bool
+	KeyServices     []keyservice.KeyServiceClient
+	DecryptionOrder []string
 }
 
 // LoadEncryptedFileWithBugFixes is a wrapper around LoadEncryptedFile which includes

--- a/cmd/sops/decrypt.go
+++ b/cmd/sops/decrypt.go
@@ -15,13 +15,14 @@ const notBinaryHint = ("This is likely not an encrypted binary file?" +
 	" If not, use --output-type to select the correct output type.")
 
 type decryptOpts struct {
-	Cipher      sops.Cipher
-	InputStore  sops.Store
-	OutputStore sops.Store
-	InputPath   string
-	IgnoreMAC   bool
-	Extract     []interface{}
-	KeyServices []keyservice.KeyServiceClient
+	Cipher          sops.Cipher
+	InputStore      sops.Store
+	OutputStore     sops.Store
+	InputPath       string
+	IgnoreMAC       bool
+	Extract         []interface{}
+	KeyServices     []keyservice.KeyServiceClient
+	DecryptionOrder []string
 }
 
 func decrypt(opts decryptOpts) (decryptedFile []byte, err error) {
@@ -37,10 +38,11 @@ func decrypt(opts decryptOpts) (decryptedFile []byte, err error) {
 	}
 
 	_, err = common.DecryptTree(common.DecryptTreeOpts{
-		Cipher:      opts.Cipher,
-		IgnoreMac:   opts.IgnoreMAC,
-		Tree:        tree,
-		KeyServices: opts.KeyServices,
+		Cipher:          opts.Cipher,
+		IgnoreMac:       opts.IgnoreMAC,
+		Tree:            tree,
+		KeyServices:     opts.KeyServices,
+		DecryptionOrder: opts.DecryptionOrder,
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/sops/edit.go
+++ b/cmd/sops/edit.go
@@ -20,13 +20,14 @@ import (
 )
 
 type editOpts struct {
-	Cipher         sops.Cipher
-	InputStore     common.Store
-	OutputStore    common.Store
-	InputPath      string
-	IgnoreMAC      bool
-	KeyServices    []keyservice.KeyServiceClient
-	ShowMasterKeys bool
+	Cipher          sops.Cipher
+	InputStore      common.Store
+	OutputStore     common.Store
+	InputPath       string
+	IgnoreMAC       bool
+	KeyServices     []keyservice.KeyServiceClient
+	DecryptionOrder []string
+	ShowMasterKeys  bool
 }
 
 type editExampleOpts struct {
@@ -96,7 +97,11 @@ func edit(opts editOpts) ([]byte, error) {
 	}
 	// Decrypt the file
 	dataKey, err := common.DecryptTree(common.DecryptTreeOpts{
-		Cipher: opts.Cipher, IgnoreMac: opts.IgnoreMAC, Tree: tree, KeyServices: opts.KeyServices,
+		Cipher:          opts.Cipher,
+		IgnoreMac:       opts.IgnoreMAC,
+		Tree:            tree,
+		KeyServices:     opts.KeyServices,
+		DecryptionOrder: opts.DecryptionOrder,
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/sops/rotate.go
+++ b/cmd/sops/rotate.go
@@ -20,15 +20,17 @@ type rotateOpts struct {
 	AddMasterKeys    []keys.MasterKey
 	RemoveMasterKeys []keys.MasterKey
 	KeyServices      []keyservice.KeyServiceClient
+	DecryptionOrder  []string
 }
 
 func rotate(opts rotateOpts) ([]byte, error) {
 	tree, err := common.LoadEncryptedFileWithBugFixes(common.GenericDecryptOpts{
-		Cipher:      opts.Cipher,
-		InputStore:  opts.InputStore,
-		InputPath:   opts.InputPath,
-		IgnoreMAC:   opts.IgnoreMAC,
-		KeyServices: opts.KeyServices,
+		Cipher:          opts.Cipher,
+		InputStore:      opts.InputStore,
+		InputPath:       opts.InputPath,
+		IgnoreMAC:       opts.IgnoreMAC,
+		KeyServices:     opts.KeyServices,
+		DecryptionOrder: opts.DecryptionOrder,
 	})
 	if err != nil {
 		return nil, err
@@ -39,8 +41,11 @@ func rotate(opts rotateOpts) ([]byte, error) {
 	})
 
 	_, err = common.DecryptTree(common.DecryptTreeOpts{
-		Cipher: opts.Cipher, IgnoreMac: opts.IgnoreMAC, Tree: tree,
-		KeyServices: opts.KeyServices,
+		Cipher:          opts.Cipher,
+		IgnoreMac:       opts.IgnoreMAC,
+		Tree:            tree,
+		KeyServices:     opts.KeyServices,
+		DecryptionOrder: opts.DecryptionOrder,
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/sops/set.go
+++ b/cmd/sops/set.go
@@ -10,14 +10,15 @@ import (
 )
 
 type setOpts struct {
-	Cipher      sops.Cipher
-	InputStore  sops.Store
-	OutputStore sops.Store
-	InputPath   string
-	IgnoreMAC   bool
-	TreePath    []interface{}
-	Value       interface{}
-	KeyServices []keyservice.KeyServiceClient
+	Cipher          sops.Cipher
+	InputStore      sops.Store
+	OutputStore     sops.Store
+	InputPath       string
+	IgnoreMAC       bool
+	TreePath        []interface{}
+	Value           interface{}
+	KeyServices     []keyservice.KeyServiceClient
+	DecryptionOrder []string
 }
 
 func set(opts setOpts) ([]byte, error) {
@@ -36,10 +37,11 @@ func set(opts setOpts) ([]byte, error) {
 
 	// Decrypt the file
 	dataKey, err := common.DecryptTree(common.DecryptTreeOpts{
-		Cipher:      opts.Cipher,
-		IgnoreMac:   opts.IgnoreMAC,
-		Tree:        tree,
-		KeyServices: opts.KeyServices,
+		Cipher:          opts.Cipher,
+		IgnoreMac:       opts.IgnoreMAC,
+		Tree:            tree,
+		KeyServices:     opts.KeyServices,
+		DecryptionOrder: opts.DecryptionOrder,
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/sops/subcommand/groups/add.go
+++ b/cmd/sops/subcommand/groups/add.go
@@ -10,13 +10,14 @@ import (
 
 // AddOpts are the options for adding a key group to a SOPS file
 type AddOpts struct {
-	InputPath      string
-	InputStore     sops.Store
-	OutputStore    sops.Store
-	Group          sops.KeyGroup
-	GroupThreshold int
-	InPlace        bool
-	KeyServices    []keyservice.KeyServiceClient
+	InputPath       string
+	InputStore      sops.Store
+	OutputStore     sops.Store
+	Group           sops.KeyGroup
+	GroupThreshold  int
+	InPlace         bool
+	KeyServices     []keyservice.KeyServiceClient
+	DecryptionOrder []string
 }
 
 // Add adds a key group to a SOPS file
@@ -25,7 +26,7 @@ func Add(opts AddOpts) error {
 	if err != nil {
 		return err
 	}
-	dataKey, err := tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices)
+	dataKey, err := tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices, opts.DecryptionOrder)
 	if err != nil {
 		return err
 	}

--- a/cmd/sops/subcommand/groups/delete.go
+++ b/cmd/sops/subcommand/groups/delete.go
@@ -12,13 +12,14 @@ import (
 
 // DeleteOpts are the options for deleting a key group from a SOPS file
 type DeleteOpts struct {
-	InputPath      string
-	InputStore     sops.Store
-	OutputStore    sops.Store
-	Group          uint
-	GroupThreshold int
-	InPlace        bool
-	KeyServices    []keyservice.KeyServiceClient
+	InputPath       string
+	InputStore      sops.Store
+	OutputStore     sops.Store
+	Group           uint
+	GroupThreshold  int
+	InPlace         bool
+	KeyServices     []keyservice.KeyServiceClient
+	DecryptionOrder []string
 }
 
 // Delete deletes a key group from a SOPS file
@@ -27,7 +28,7 @@ func Delete(opts DeleteOpts) error {
 	if err != nil {
 		return err
 	}
-	dataKey, err := tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices)
+	dataKey, err := tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices, opts.DecryptionOrder)
 	if err != nil {
 		return err
 	}

--- a/cmd/sops/subcommand/publish/publish.go
+++ b/cmd/sops/subcommand/publish/publish.go
@@ -27,15 +27,16 @@ func init() {
 
 // Opts represents publish options and config
 type Opts struct {
-	Interactive    bool
-	Cipher         sops.Cipher
-	ConfigPath     string
-	InputPath      string
-	KeyServices    []keyservice.KeyServiceClient
-	InputStore     sops.Store
-	OmitExtensions bool
-	Recursive      bool
-	RootPath       string
+	Interactive     bool
+	Cipher          sops.Cipher
+	ConfigPath      string
+	InputPath       string
+	KeyServices     []keyservice.KeyServiceClient
+	DecryptionOrder []string
+	InputStore      sops.Store
+	OmitExtensions  bool
+	Recursive       bool
+	RootPath        string
 }
 
 // Run publish operation
@@ -81,10 +82,11 @@ func Run(opts Opts) error {
 		if len(conf.KeyGroups[0]) != 0 {
 			log.Debug("Re-encrypting tree before publishing")
 			_, err = common.DecryptTree(common.DecryptTreeOpts{
-				Cipher:      opts.Cipher,
-				IgnoreMac:   false,
-				Tree:        tree,
-				KeyServices: opts.KeyServices,
+				Cipher:          opts.Cipher,
+				IgnoreMac:       false,
+				Tree:            tree,
+				KeyServices:     opts.KeyServices,
+				DecryptionOrder: opts.DecryptionOrder,
 			})
 			if err != nil {
 				return err
@@ -137,10 +139,11 @@ func Run(opts Opts) error {
 		}
 	case *publish.VaultDestination:
 		_, err = common.DecryptTree(common.DecryptTreeOpts{
-			Cipher:      opts.Cipher,
-			IgnoreMac:   false,
-			Tree:        tree,
-			KeyServices: opts.KeyServices,
+			Cipher:          opts.Cipher,
+			IgnoreMac:       false,
+			Tree:            tree,
+			KeyServices:     opts.KeyServices,
+			DecryptionOrder: opts.DecryptionOrder,
 		})
 		if err != nil {
 			return err

--- a/cmd/sops/subcommand/updatekeys/updatekeys.go
+++ b/cmd/sops/subcommand/updatekeys/updatekeys.go
@@ -14,12 +14,13 @@ import (
 
 // Opts represents key operation options and config
 type Opts struct {
-	InputPath   string
-	GroupQuorum int
-	KeyServices []keyservice.KeyServiceClient
-	Interactive bool
-	ConfigPath  string
-	InputType   string
+	InputPath       string
+	GroupQuorum     int
+	KeyServices     []keyservice.KeyServiceClient
+	DecryptionOrder []string
+	Interactive     bool
+	ConfigPath      string
+	InputType       string
 }
 
 // UpdateKeys update the keys for a given file
@@ -83,7 +84,7 @@ func updateFile(opts Opts) error {
 			return nil
 		}
 	}
-	key, err := tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices)
+	key, err := tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices, opts.DecryptionOrder)
 	if err != nil {
 		return common.NewExitError(err, codes.CouldNotRetrieveKey)
 	}

--- a/gcpkms/keysource.go
+++ b/gcpkms/keysource.go
@@ -23,6 +23,8 @@ const (
 	// a path to a credentials file, or directly as the variable's value in JSON
 	// format.
 	SopsGoogleCredentialsEnv = "GOOGLE_CREDENTIALS"
+	// KeyTypeIdentifier is the string used to identify a GCP KMS MasterKey.
+	KeyTypeIdentifier = "gcp_kms"
 )
 
 var (
@@ -194,6 +196,11 @@ func (key MasterKey) ToMap() map[string]interface{} {
 	out["created_at"] = key.CreationDate.UTC().Format(time.RFC3339)
 	out["enc"] = key.EncryptedKey
 	return out
+}
+
+// TypeToIdentifier returns the string identifier for the MasterKey type.
+func (key *MasterKey) TypeToIdentifier() string {
+	return KeyTypeIdentifier
 }
 
 // newKMSClient returns a GCP KMS client configured with the credentialJSON

--- a/hcvault/keysource.go
+++ b/hcvault/keysource.go
@@ -21,6 +21,11 @@ import (
 	"github.com/getsops/sops/v3/logging"
 )
 
+const (
+	// KeyTypeIdentifier is the string used to identify a Vault MasterKey.
+	KeyTypeIdentifier = "hc_vault"
+)
+
 func init() {
 	log = logging.NewLogger("VAULT_TRANSIT")
 }
@@ -214,6 +219,11 @@ func (key MasterKey) ToMap() map[string]interface{} {
 	out["enc"] = key.EncryptedKey
 	out["created_at"] = key.CreationDate.UTC().Format(time.RFC3339)
 	return out
+}
+
+// TypeToIdentifier returns the string identifier for the MasterKey type.
+func (key *MasterKey) TypeToIdentifier() string {
+	return KeyTypeIdentifier
 }
 
 // encryptPath returns the path for Encrypt requests.

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -10,4 +10,5 @@ type MasterKey interface {
 	NeedsRotation() bool
 	ToString() string
 	ToMap() map[string]interface{}
+	TypeToIdentifier() string
 }

--- a/kms/keysource.go
+++ b/kms/keysource.go
@@ -3,7 +3,7 @@ Package kms contains an implementation of the github.com/getsops/sops/v3.MasterK
 interface that encrypts and decrypts the data key using AWS KMS with the SDK
 for Go V2.
 */
-package kms //import "github.com/getsops/sops/v3/kms"
+package kms // import "github.com/getsops/sops/v3/kms"
 
 import (
 	"context"
@@ -19,8 +19,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
-	"github.com/getsops/sops/v3/logging"
 	"github.com/sirupsen/logrus"
+
+	"github.com/getsops/sops/v3/logging"
 )
 
 const (
@@ -34,6 +35,8 @@ const (
 	roleSessionNameLengthLimit = 64
 	// kmsTTL is the duration after which a MasterKey requires rotation.
 	kmsTTL = time.Hour * 24 * 30 * 6
+	// KeyTypeIdentifier is the string used to identify an AWS KMS MasterKey.
+	KeyTypeIdentifier = "kms"
 )
 
 var (
@@ -295,6 +298,11 @@ func (key MasterKey) ToMap() map[string]interface{} {
 		out["context"] = outcontext
 	}
 	return out
+}
+
+// TypeToIdentifier returns the string identifier for the MasterKey type.
+func (key *MasterKey) TypeToIdentifier() string {
+	return KeyTypeIdentifier
 }
 
 // createKMSConfig returns an AWS config with the credentialsProvider of the

--- a/pgp/keysource.go
+++ b/pgp/keysource.go
@@ -4,7 +4,7 @@ interface that encrypts and decrypts the data key by first trying with the
 github.com/ProtonMail/go-crypto/openpgp package and if that fails, by calling
 the "gpg" binary.
 */
-package pgp //import "github.com/getsops/sops/v3/pgp"
+package pgp // import "github.com/getsops/sops/v3/pgp"
 
 import (
 	"bytes"
@@ -22,12 +22,15 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/ProtonMail/go-crypto/openpgp/armor"
 	gpgagent "github.com/getsops/gopgagent"
-	"github.com/getsops/sops/v3/logging"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/term"
+
+	"github.com/getsops/sops/v3/logging"
 )
 
 const (
+	// KeyTypeIdentifier is the string used to identify a PGP MasterKey.
+	KeyTypeIdentifier = "pgp"
 	// SopsGpgExecEnv can be set as an environment variable to overwrite the
 	// GnuPG binary used.
 	SopsGpgExecEnv = "SOPS_GPG_EXEC"
@@ -447,6 +450,11 @@ func (key MasterKey) ToMap() map[string]interface{} {
 	out["created_at"] = key.CreationDate.UTC().Format(time.RFC3339)
 	out["enc"] = key.EncryptedKey
 	return out
+}
+
+// TypeToIdentifier returns the string identifier for the MasterKey type.
+func (key *MasterKey) TypeToIdentifier() string {
+	return KeyTypeIdentifier
 }
 
 // retrievePubKey attempts to retrieve the public key from the public keyring

--- a/sops_test.go
+++ b/sops_test.go
@@ -7,6 +7,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/getsops/sops/v3/age"
+	"github.com/getsops/sops/v3/hcvault"
+	"github.com/getsops/sops/v3/pgp"
 )
 
 type reverseCipher struct{}
@@ -841,4 +845,62 @@ func TestEmitAsMap(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Equal(t, expected, data)
 	}
+}
+
+func TestSortKeyGroupIndices(t *testing.T) {
+	t.Run("default order", func(t *testing.T) {
+		group := KeyGroup{&hcvault.MasterKey{}, &age.MasterKey{}, &pgp.MasterKey{}}
+		expected := []int{1, 2, 0}
+		indices := sortKeyGroupIndices(group, DefaultDecryptionOrder)
+		assert.Equal(t, expected, indices)
+	})
+
+	t.Run("different keygroup", func(t *testing.T) {
+		group := KeyGroup{&hcvault.MasterKey{}, &pgp.MasterKey{}, &age.MasterKey{}}
+		expected := []int{2, 1, 0}
+		indices := sortKeyGroupIndices(group, DefaultDecryptionOrder)
+		assert.Equal(t, expected, indices)
+	})
+
+	t.Run("repeated key", func(t *testing.T) {
+		group := KeyGroup{&pgp.MasterKey{}, &hcvault.MasterKey{}, &pgp.MasterKey{}, &age.MasterKey{}}
+		expected := []int{3, 0, 2, 1}
+		indices := sortKeyGroupIndices(group, DefaultDecryptionOrder)
+		assert.Equal(t, expected, indices)
+	})
+
+	t.Run("full order", func(t *testing.T) {
+		group := KeyGroup{&hcvault.MasterKey{}, &pgp.MasterKey{}, &age.MasterKey{}}
+		expected := []int{1, 2, 0}
+		indices := sortKeyGroupIndices(group, []string{"pgp", "age", "hc_vault"})
+		assert.Equal(t, expected, indices)
+	})
+
+	t.Run("empty order", func(t *testing.T) {
+		group := KeyGroup{&hcvault.MasterKey{}, &pgp.MasterKey{}, &age.MasterKey{}}
+		expected := []int{0, 1, 2}
+		indices := sortKeyGroupIndices(group, []string{})
+		assert.Equal(t, expected, indices)
+	})
+
+	t.Run("one match", func(t *testing.T) {
+		group := KeyGroup{&hcvault.MasterKey{}, &pgp.MasterKey{}, &age.MasterKey{}}
+		expected := []int{2, 0, 1}
+		indices := sortKeyGroupIndices(group, []string{"azure_kv", "age"})
+		assert.Equal(t, expected, indices)
+	})
+
+	t.Run("nonmatching order", func(t *testing.T) {
+		group := KeyGroup{&pgp.MasterKey{}, &hcvault.MasterKey{}, &age.MasterKey{}}
+		expected := []int{0, 1, 2}
+		indices := sortKeyGroupIndices(group, []string{"azure_kv"})
+		assert.Equal(t, expected, indices)
+	})
+
+	t.Run("nonexistent keys", func(t *testing.T) {
+		group := KeyGroup{&hcvault.MasterKey{}, &pgp.MasterKey{}, &age.MasterKey{}}
+		expected := []int{2, 1, 0}
+		indices := sortKeyGroupIndices(group, []string{"dummy1", "age", "dummy2", "pgp", "dummy3"})
+		assert.Equal(t, expected, indices)
+	})
 }


### PR DESCRIPTION
This is more generic way to address https://github.com/getsops/sops/issues/305. As suggested in https://github.com/getsops/sops/issues/305#issuecomment-1793766331 and https://github.com/getsops/sops/issues/305#issuecomment-1793768768 it supports `--decryption-order` and **SOPS_DECRYPTION_ORDER** to specify the order in which decryption method are tried. Default order is `age,pgp`, so it covers functionality of #1121 too.

Couple of additional thoughts:
-  Sorting just indices as suggested in https://github.com/getsops/sops/pull/1121#discussion_r1382581918 together with priorities makes code a bit cryptic. Maybe using copy() to clone the group slice and sort the cloned slice could be acceptable alternative (since we don't modify the elements, but only the order)?
- Passing DecryptionOrder through number of options and function calls is a bit cumbersome. Would it make sense to include DecryptionOrder and KeyServices together in a struct since they seem to be used mostly together?