### PR TITLE
README: Correctly tag code as yaml-stream

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1193,7 +1193,7 @@ YAML Streams
 formats like ``JSON`` do not. SOPS is able to handle both. This means the
 following multi-document will be encrypted as expected:
 
-.. code:: yaml
+.. code:: yaml-stream
 
     ---
     data: foo


### PR DESCRIPTION
Right now the rstcheck test fails because a YAML stream with two documents is labelled as a YAML file.