### PR TITLE
Added support for access tokens in gcpkms

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -235,6 +235,44 @@ you can enable application default credentials using the sdk:
 
     $ gcloud auth application-default login
 
+It's also possible to configure the credentials using the env var ``GOOGLE_CREDENTIALS``.
+This can either point to a file or JSON content.
+
+.. code:: sh
+
+    export GOOGLE_CREDENTIALS=$(cat credentials.json)
+    export GOOGLE_CREDENTIALS=credentials.json
+
+Supported formats are:
+
+Credentials file:
+
+.. code:: json
+
+    {
+        "type": "service_account",
+        "project_id": "my-project",
+        "private_key_id": "66a4119f8aefbe8687ef0e14c6e7e0e1844b7950",
+        "private_key": "***",
+        "client_email": "my-service-account@my-project.iam.gserviceaccount.com",
+        "client_id": "1234567890",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+        "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/my-service-account%40my-project.iam.gserviceaccount.com",
+        "universe_domain": "googleapis.com"
+    }
+
+Access token:
+
+.. code:: json
+
+    {
+      "access_token": "***",
+      "expires_in": 3599,
+      "token_type": "Bearer"
+    }
+
 Encrypting/decrypting with GCP KMS requires a KMS ResourceID. You can use the
 cloud console the get the ResourceID or you can create one using the gcloud
 sdk:

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli v1.22.15
 	golang.org/x/net v0.27.0
+	golang.org/x/oauth2 v0.21.0
 	golang.org/x/sys v0.23.0
 	golang.org/x/term v0.22.0
 	google.golang.org/api v0.190.0
@@ -125,7 +126,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.27.0 // indirect
 	go.opentelemetry.io/otel/trace v1.27.0 // indirect
 	golang.org/x/crypto v0.25.0 // indirect
-	golang.org/x/oauth2 v0.21.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 	golang.org/x/time v0.5.0 // indirect


### PR DESCRIPTION
This PR adds support for access token (via the `GOOGLE_CREDENTIALS` env var).

If the env var `GOOGLE_CREDENTIALS` is _not_ set, the gcloud sdk fetches an access token from the [instance metadata endpoint](https://cloud.google.com/appengine/docs/legacy/standard/java/accessing-instance-metadata#identifying_which_metadata_endpoint_to_use) `http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token`. 

In our workload on GKE, we don't want to use the access token returned by the metadata endpoint directly. We use this access token to [impersonate another service account](https://cloud.google.com/iam/docs/create-short-lived-credentials-direct#sa-credentials-oauth), which has the minimum of permissions required for the kms decrypt. 

There is no facility to set access tokens in sops, only static (long lived) credentials via the credentials file/`GOOGLE_CREDENTIALS`.