### PR TITLE
Fix TestGnuPGHome_Validate/wrong_permissions 

### DIFF
--- a/pgp/keysource_test.go
+++ b/pgp/keysource_test.go
@@ -129,8 +129,11 @@ func TestGnuPGHome_Validate(t *testing.T) {
 	})
 
 	t.Run("wrong permissions", func(t *testing.T) {
-		// Is created with 0755
 		tmpDir := t.TempDir()
+
+		err := os.Chmod(tmpDir, 0o755)
+		assert.NoError(t, err)
+
 		assert.Error(t, GnuPGHome(tmpDir).Validate())
 	})
 


### PR DESCRIPTION
On my stock Ubuntu 22.04 machine with Go 1.21 one of the tests fails:

```
--- FAIL: TestGnuPGHome_Validate (0.00s)
    --- FAIL: TestGnuPGHome_Validate/wrong_permissions (0.00s)
        keysource_test.go:134: 
                Error Trace:    /home/xmo/pro/sops/pgp/keysource_test.go:134
                Error:          An error is expected but got nil.
                Test:           TestGnuPGHome_Validate/wrong_permissions
```

The test assumes that `t.TempDir()` returns a directory with mode `0755`. 

Taking a look at [testing.go:1221 ](https://cs.opensource.google/go/go/+/refs/tags/go1.21.5:src/testing/testing.go;l=1221) shows that this uses [os.MkdirTemp()](https://cs.opensource.google/go/go/+/refs/tags/go1.21.5:src/os/tempfile.go;l=94), which calls `Mkdir(name, 0700)`, causing the test to fail.

To fix this I modified the test to explicitly set the mode on the tempdir to 0755.