### PR TITLE
fix a bug where not having a config results in a panic

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -1075,7 +1075,11 @@ func loadStoresConfig(context *cli.Context, path string) (*config.StoresConfig, 
 		configPath = context.String("config")
 	} else {
 		// Ignore config not found errors returned from FindConfigFile since the config file is not mandatory
-		configPath, _ = config.FindConfigFile(".")
+		foundPath, err := config.FindConfigFile(".")
+		if err != nil {
+			return config.NewStoresConfig(), nil
+		}
+		configPath = foundPath
 	}
 	return config.LoadStoresConfig(configPath)
 }


### PR DESCRIPTION
If you execute sops without a config file, you'll get a lovely panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xdfa373]

goroutine 1 [running]:
github.com/getsops/sops/v3/cmd/sops/common.newYamlStore(0x0)
        /home/tanner/pro/sops/cmd/sops/common/common.go:58 +0x13
github.com/getsops/sops/v3/cmd/sops/common.StoreForFormat(...)
        /home/tanner/pro/sops/cmd/sops/common/common.go:162
github.com/getsops/sops/v3/cmd/sops/common.DefaultStoreForPathOrFormat(0x10bf3c2?, {0xc000048090, 0x24}, {0x0?, 0x10c753b?})
        /home/tanner/pro/sops/cmd/sops/common/common.go:177 +0x9d
main.inputStore(0xc0001ff340, {0xc000048090, 0x24})
        /home/tanner/pro/sops/cmd/sops/main.go:1085 +0x65
main.main.func8(0xc0001ff340)
        /home/tanner/pro/sops/cmd/sops/main.go:796 +0x770
github.com/urfave/cli.HandleAction({0xeca5a0?, 0x1129d08?}, 0xc0000ea700?)
        /home/tanner/pro/sops/vendor/github.com/urfave/cli/app.go:524 +0x50
github.com/urfave/cli.(*App).Run(0xc0000ea700, {0xc0001b2000, 0x4, 0x4})
        /home/tanner/pro/sops/vendor/github.com/urfave/cli/app.go:286 +0x766
main.main()
        /home/tanner/pro/sops/cmd/sops/main.go:1018 +0x35be
```

This problem was introduced by e9e2346fd. This commit changed the signature of common.storeConstructor from

```go
type storeConstructor = func() Store

func newBinaryStore() Store {
  return &json.BinaryStore{}
}

func newDotenvStore() Store {
  return &dotenv.Store{}
}

func newIniStore() Store {
  return &ini.Store{}
}

func newJsonStore() Store {
  return &json.Store{}
}

func newYamlStore() Store {
  return &yaml.Store{}
}
```
to
```go
type storeConstructor = func(*config.StoresConfig) Store

func newBinaryStore(c *config.StoresConfig) Store {
  return json.NewBinaryStore(&c.JSONBinary)
}

func newDotenvStore(c *config.StoresConfig) Store {
  return dotenv.NewStore(&c.Dotenv)
}

func newIniStore(c *config.StoresConfig) Store {
  return ini.NewStore(&c.INI)
}

func newJsonStore(c *config.StoresConfig) Store {
  return json.NewStore(&c.JSON)
}

func newYamlStore(c *config.StoresConfig) Store {
  return yaml.NewStore(&c.YAML)
}

```
All of the storeConstructor functions attempt to dereference the StoresConfig pointer, which causes a panic if it's nil.


inputStore and outputStore both use the following function to load a StoresConfig:
```go
func loadStoresConfig(context *cli.Context, path string) (*config.StoresConfig, error) {
  var configPath string
  if context.String("config") != "" { 
    configPath = context.String("config")
  } else {
    // Ignore config not found errors returned from FindConfigFile since the config file is not mandatory
    configPath, _ = config.FindConfigFile(".")
  }
  return config.LoadStoresConfig(configPath)
}
```

If loadStoresConfig cannot find a config file, it returns `nil, err`. inputStore ignores the error from loadStoresConfig and invokes common.DefaultStoreForPathOrFormat(nil) which eventually invokes a storeConstructor with a nil pointer.

The comment in loadStoresConfig says config files aren't necessary so to fix this we just construct a new StoresConfig if we can't find a config file.

This issue doesn't show up if you run sops in the git repo, since there's always a .sops.yaml for demonstration purposes.  Without that file, sops will panic.