### PR TITLE
Docs: indent is used both for encryption and decryption

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1192,6 +1192,11 @@ by configuring ``.sops.yaml`` with:
       yaml:
           indent: 2
 
+.. note::
+
+  The YAML emitter used by sops only supports values between 2 and 9. If you specify 1,
+  or 10 and larger, the indent will be 2.
+
 YAML anchors
 ~~~~~~~~~~~~
 

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -706,7 +706,7 @@ func main() {
 		},
 		cli.IntFlag{
 			Name:  "indent",
-			Usage: "the number of spaces to indent YAML or JSON encoded file for encryption",
+			Usage: "the number of spaces to indent YAML or JSON encoded file",
 		},
 		cli.BoolFlag{
 			Name:  "verbose",


### PR DESCRIPTION
Right now the documenation of the `--indent` option says it's only used for encryption, while it is also used for decryption.

While testing this I noticed that for indenting YAML files, only indents of 2 to 9 are used. If you specify 1, or 10 or larger, the indent is ignored. This comes from go-yaml: https://github.com/go-yaml/yaml/blob/f6f7691b1fdeb513f56608cd2c32c51f8194bf51/emitterc.go#L328-L330

CC @Ph0tonic