### PR TITLE
Move extraction of encryption and rotation options to separate functions

### DIFF
--- a/cmd/sops/edit.go
+++ b/cmd/sops/edit.go
@@ -32,13 +32,7 @@ type editOpts struct {
 
 type editExampleOpts struct {
 	editOpts
-	UnencryptedSuffix string
-	EncryptedSuffix   string
-	UnencryptedRegex  string
-	EncryptedRegex    string
-	MACOnlyEncrypted  bool
-	KeyGroups         []sops.KeyGroup
-	GroupThreshold    int
+	encryptConfig
 }
 
 type runEditorUntilOkOpts struct {
@@ -61,16 +55,7 @@ func editExample(opts editExampleOpts) ([]byte, error) {
 	}
 	tree := sops.Tree{
 		Branches: branches,
-		Metadata: sops.Metadata{
-			KeyGroups:         opts.KeyGroups,
-			UnencryptedSuffix: opts.UnencryptedSuffix,
-			EncryptedSuffix:   opts.EncryptedSuffix,
-			UnencryptedRegex:  opts.UnencryptedRegex,
-			EncryptedRegex:    opts.EncryptedRegex,
-			MACOnlyEncrypted:  opts.MACOnlyEncrypted,
-			Version:           version.Version,
-			ShamirThreshold:   opts.GroupThreshold,
-		},
+		Metadata: metadataFromEncryptionConfig(opts.encryptConfig),
 		FilePath: path,
 	}
 


### PR DESCRIPTION
Preparation for a rewrite of https://github.com/getsops/sops/pull/1343, which aims at implementing https://github.com/getsops/sops/issues/1333 (Make encrypt, decrypt, rotate, set, and edit proper commands).

This simplifies the main command handler to a more manageable ~180 lines of code, and heavily reduces the copy'n'paste that would happen in an implementation like https://github.com/getsops/sops/pull/1343.

This is #1387 without #974. Once merged I'll update #1387 to contain a version of #974 rebased to the then current `main` branch.
