### PR TITLE
Add separate subcommands for encryption, decryption, rotating, editing, and setting values

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,7 +154,7 @@ To decrypt a file in a ``cat`` fashion, use the ``-d`` flag:
 
 .. code:: sh
 
-    $ sops -d mynewtestfile.yaml
+    $ sops decrypt mynewtestfile.yaml
 
 SOPS encrypted files contain the necessary information to decrypt their content.
 All a user of SOPS needs is valid AWS credentials and the necessary
@@ -200,7 +200,7 @@ the ``--age`` option or the **SOPS_AGE_RECIPIENTS** environment variable:
 
 .. code:: sh
 
-    $ sops --encrypt --age age1yt3tfqlfrwdwx0z0ynwplcr6qxcxfaqycuprpmy89nr83ltx74tqdpszlw test.yaml > test.enc.yaml
+    $ sops encrypt --age age1yt3tfqlfrwdwx0z0ynwplcr6qxcxfaqycuprpmy89nr83ltx74tqdpszlw test.yaml > test.enc.yaml
 
 When decrypting a file with the corresponding identity, SOPS will look for a
 text file name ``keys.txt`` located in a ``sops`` subdirectory of your user
@@ -250,11 +250,11 @@ sdk:
 
 Now you can encrypt a file using::
 
-    $ sops --encrypt --gcp-kms projects/my-project/locations/global/keyRings/sops/cryptoKeys/sops-key test.yaml > test.enc.yaml
+    $ sops encrypt --gcp-kms projects/my-project/locations/global/keyRings/sops/cryptoKeys/sops-key test.yaml > test.enc.yaml
 
 And decrypt it using::
 
-     $ sops --decrypt test.enc.yaml
+     $ sops decrypt test.enc.yaml
 
 Encrypting using Azure Key Vault
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -324,11 +324,11 @@ from the commandline:
 
 Now you can encrypt a file using::
 
-    $ sops --encrypt --azure-kv https://sops.vault.azure.net/keys/sops-key/some-string test.yaml > test.enc.yaml
+    $ sops encrypt --azure-kv https://sops.vault.azure.net/keys/sops-key/some-string test.yaml > test.enc.yaml
 
 And decrypt it using::
 
-    $ sops --decrypt test.enc.yaml
+    $ sops decrypt test.enc.yaml
 
 
 Encrypting and decrypting from other programs
@@ -344,7 +344,7 @@ To decrypt data, you can simply do:
 
 .. code:: sh
 
-	$ cat encrypted-data | sops --decrypt /dev/stdin > decrypted-data
+	$ cat encrypted-data | sops decrypt /dev/stdin > decrypted-data
 
 To control the input and output format, pass ``--input-type`` and ``--output-type`` as appropriate. By default,
 ``sops`` determines the input and output format from the provided filename, which is ``/dev/stdin`` here, and
@@ -354,7 +354,7 @@ For example, to decrypt YAML data and obtain the decrypted result as YAML, use:
 
 .. code:: sh
 
-	$ cat encrypted-data | sops --input-type yaml --output-type yaml --decrypt /dev/stdin > decrypted-data
+	$ cat encrypted-data | sops decrypt --input-type yaml --output-type yaml /dev/stdin > decrypted-data
 
 To encrypt, it is important to note that SOPS also uses the filename to look up the correct creation rule from
 ``.sops.yaml``. Likely ``/dev/stdin`` will not match a creation rule, or only match the fallback rule without
@@ -363,7 +363,7 @@ parameter which allows you to tell SOPS which filename to use to match creation 
 
 .. code:: sh
 
-	$ echo 'foo: bar' | sops --filename-override path/filename.sops.yaml --encrypt /dev/stdin > encrypted-data
+	$ echo 'foo: bar' | sops encrypt --filename-override path/filename.sops.yaml /dev/stdin > encrypted-data
 
 SOPS will find a matching creation rule for ``path/filename.sops.yaml`` in ``.sops.yaml`` and use that one to
 encrypt the data from stdin. This filename will also be used to determine the input and output store. As always,
@@ -372,7 +372,7 @@ the input store type can be adjusted by passing ``--input-type``, and the output
 
 .. code:: sh
 
-	$ echo foo=bar | sops --filename-override path/filename.sops.yaml --input-type dotenv --encrypt /dev/stdin > encrypted-data
+	$ echo foo=bar | sops encrypt --filename-override path/filename.sops.yaml --input-type dotenv /dev/stdin > encrypted-data
 
 
 Encrypting using Hashicorp Vault
@@ -423,7 +423,7 @@ To easily deploy Vault locally: (DO NOT DO THIS FOR PRODUCTION!!!)
     $ vault write sops/keys/thirdkey type=chacha20-poly1305
     Success! Data written to: sops/keys/thirdkey
 
-    $ sops --encrypt --hc-vault-transit $VAULT_ADDR/v1/sops/keys/firstkey vault_example.yml
+    $ sops encrypt --hc-vault-transit $VAULT_ADDR/v1/sops/keys/firstkey vault_example.yml
 
     $ cat <<EOF > .sops.yaml
     creation_rules:
@@ -433,7 +433,7 @@ To easily deploy Vault locally: (DO NOT DO THIS FOR PRODUCTION!!!)
           hc_vault_transit_uri: "$VAULT_ADDR/v1/sops/keys/thirdkey"
     EOF
 
-    $ sops --verbose -e prod/raw.yaml > prod/encrypted.yaml
+    $ sops encrypt --verbose prod/raw.yaml > prod/encrypted.yaml
 
 Adding and removing keys
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -888,7 +888,7 @@ You can then decrypt the file the same way as with any other SOPS file:
 
 .. code:: sh
 
-    $ sops -d example.json
+    $ sops decrypt example.json
 
 Key service
 ~~~~~~~~~~~
@@ -928,14 +928,14 @@ service exposed on the unix socket located in ``/tmp/sops.sock``, you can run:
 
 .. code:: sh
 
-    $ sops --keyservice unix:///tmp/sops.sock -d file.yaml`
+    $ sops decrypt --keyservice unix:///tmp/sops.sock file.yaml`
 
 And if you only want to use the key service exposed on the unix socket located
 in ``/tmp/sops.sock`` and not the local key service, you can run:
 
 .. code:: sh
 
-    $ sops --enable-local-keyservice=false --keyservice unix:///tmp/sops.sock -d file.yaml
+    $ sops decrypt --enable-local-keyservice=false --keyservice unix:///tmp/sops.sock file.yaml
 
 Auditing
 ~~~~~~~~
@@ -1002,7 +1002,7 @@ written to disk.
 .. code:: sh
 
     # print secrets to stdout to confirm values
-    $ sops -d out.json
+    $ sops decrypt out.json
     {
             "database_password": "jf48t9wfw094gf4nhdf023r",
             "AWS_ACCESS_KEY_ID": "AKIAIOSFODNN7EXAMPLE",
@@ -1152,7 +1152,7 @@ Below is an example of publishing to Vault (using token auth with a local dev in
 
     $ export VAULT_TOKEN=...
     $ export VAULT_ADDR='http://127.0.0.1:8200'
-    $ sops -d vault/test.yaml
+    $ sops decrypt vault/test.yaml
     example_string: bar
     example_number: 42
     example_map:
@@ -1193,23 +1193,23 @@ extension after encrypting a file. For example:
 
 .. code:: sh
 
-    $ sops -e -i myfile.json
-    $ sops -d myfile.json
+    $ sops encrypt -i myfile.json
+    $ sops decrypt myfile.json
 
 If you want to change the extension of the file once encrypted, you need to provide
 ``sops`` with the ``--input-type`` flag upon decryption. For example:
 
 .. code:: sh
 
-    $ sops -e myfile.json > myfile.json.enc
+    $ sops encrypt myfile.json > myfile.json.enc
 
-    $ sops -d --input-type json myfile.json.enc
+    $ sops decrypt --input-type json myfile.json.enc
 
 When operating on stdin, use the ``--input-type`` and ``--output-type`` flags as follows:
 
 .. code:: sh
 
-    $ cat myfile.json | sops --input-type json --output-type json -d /dev/stdin
+    $ cat myfile.json | sops decrypt --input-type json --output-type json /dev/stdin
 
 JSON and JSON_binary indentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1361,13 +1361,13 @@ encrypt the file, and redirect the output to a destination file.
 
     $ export SOPS_KMS_ARN="arn:aws:kms:us-west-2:927034868273:key/fe86dd69-4132-404c-ab86-4269956b4500"
     $ export SOPS_PGP_FP="C9CAB0AF1165060DB58D6D6B2653B624D620786D"
-    $ sops -e /path/to/existing/file.yaml > /path/to/new/encrypted/file.yaml
+    $ sops encrypt /path/to/existing/file.yaml > /path/to/new/encrypted/file.yaml
 
 Decrypt the file with ``-d``.
 
 .. code:: sh
 
-    $ sops -d /path/to/new/encrypted/file.yaml
+    $ sops decrypt /path/to/new/encrypted/file.yaml
 
 Encrypt or decrypt a file in place
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1378,9 +1378,9 @@ original file after encrypting or decrypting it.
 .. code:: sh
 
     # file.yaml is in cleartext
-    $ sops -e -i /path/to/existing/file.yaml
+    $ sops encrypt -i /path/to/existing/file.yaml
     # file.yaml is now encrypted
-    $ sops -d -i /path/to/existing/file.yaml
+    $ sops decrypt -i /path/to/existing/file.yaml
     # file.yaml is back in cleartext
 
 Encrypting binary files
@@ -1407,10 +1407,10 @@ In-place encryption/decryption also works on binary files.
     $ sha512sum /tmp/somerandom
     9589bb20280e9d381f7a192000498c994e921b3cdb11d2ef5a986578dc2239a340b25ef30691bac72bdb14028270828dad7e8bd31e274af9828c40d216e60cbe /tmp/somerandom
 
-    $ sops -e -i /tmp/somerandom
+    $ sops encrypt -i /tmp/somerandom
     please wait while a data encryption key is being generated and stored securely
 
-    $ sops -d -i /tmp/somerandom
+    $ sops decrypt -i /tmp/somerandom
 
     $ sha512sum /tmp/somerandom
     9589bb20280e9d381f7a192000498c994e921b3cdb11d2ef5a986578dc2239a340b25ef30691bac72bdb14028270828dad7e8bd31e274af9828c40d216e60cbe /tmp/somerandom
@@ -1424,7 +1424,7 @@ values, like keys, without needing an extra parser.
 
 .. code:: sh
 
-    $ sops -d --extract '["app2"]["key"]' ~/git/svc/sops/example.yaml
+    $ sops decrypt --extract '["app2"]["key"]' ~/git/svc/sops/example.yaml
     -----BEGIN RSA PRIVATE KEY-----
     MIIBPAIBAAJBAPTMNIyHuZtpLYc7VsHQtwOkWYobkUblmHWRmbXzlAX6K8tMf3Wf
     ImcbNkqAKnELzFAPSBeEMhrBN0PyOC9lYlMCAwEAAQJBALXD4sjuBn1E7Y9aGiMz
@@ -1441,7 +1441,7 @@ them.
 
 .. code:: sh
 
-    $ sops -d --extract '["an_array"][1]' ~/git/svc/sops/example.yaml
+    $ sops decrypt --extract '["an_array"][1]' ~/git/svc/sops/example.yaml
     secretuser2
 
 Set a sub-part in a document tree
@@ -1488,11 +1488,11 @@ to a SOPS command in the git configuration file of the repository.
 
 .. code:: sh
 
-    $ git config diff.sopsdiffer.textconv "sops -d"
+    $ git config diff.sopsdiffer.textconv "sops decrypt"
 
     $ grep -A 1 sopsdiffer .git/config
     [diff "sopsdiffer"]
-        textconv = "sops -d"
+        textconv = "sops decrypt"
 
 With this in place, calls to ``git diff`` will decrypt both previous and current
 versions of the target file prior to displaying the diff. And it even works with
@@ -1527,7 +1527,7 @@ keys that match the supplied regular expression.  For example, this command:
 
 .. code:: sh
 
-    $ sops --encrypt --encrypted-regex '^(data|stringData)$' k8s-secrets.yaml
+    $ sops encrypt --encrypted-regex '^(data|stringData)$' k8s-secrets.yaml
 
 will encrypt the values under the ``data`` and ``stringData`` keys in a YAML file
 containing kubernetes secrets.  It will not encrypt other values that help you to
@@ -1539,7 +1539,7 @@ that match the supplied regular expression. For example, this command:
 
 .. code:: sh
 
-    $ sops --encrypt --unencrypted-regex '^(description|metadata)$' k8s-secrets.yaml
+    $ sops encrypt --unencrypted-regex '^(description|metadata)$' k8s-secrets.yaml
 
 will not encrypt the values under the ``description`` and ``metadata`` keys in a YAML file
 containing kubernetes secrets, while encrypting everything else.

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -898,6 +898,406 @@ func main() {
 				return toExitError(err)
 			},
 		},
+		{
+			Name:      "rotate",
+			Usage:     "generate a new data encryption key and reencrypt all values with the new key",
+			ArgsUsage: `file`,
+			Flags: append([]cli.Flag{
+				cli.BoolFlag{
+					Name:  "in-place, i",
+					Usage: "write output back to the same file instead of stdout",
+				},
+				cli.StringFlag{
+					Name:  "output",
+					Usage: "Save the output after decryption to the file specified",
+				},
+				cli.StringFlag{
+					Name:  "input-type",
+					Usage: "currently json, yaml, dotenv and binary are supported. If not set, sops will use the file's extension to determine the type",
+				},
+				cli.StringFlag{
+					Name:  "output-type",
+					Usage: "currently json, yaml, dotenv and binary are supported. If not set, sops will use the input file's extension to determine the output format",
+				},
+				cli.StringFlag{
+					Name:  "encryption-context",
+					Usage: "comma separated list of KMS encryption context key:value pairs",
+				},
+				cli.StringFlag{
+					Name:  "add-gcp-kms",
+					Usage: "add the provided comma-separated list of GCP KMS key resource IDs to the list of master keys on the given file",
+				},
+				cli.StringFlag{
+					Name:  "rm-gcp-kms",
+					Usage: "remove the provided comma-separated list of GCP KMS key resource IDs from the list of master keys on the given file",
+				},
+				cli.StringFlag{
+					Name:  "add-azure-kv",
+					Usage: "add the provided comma-separated list of Azure Key Vault key URLs to the list of master keys on the given file",
+				},
+				cli.StringFlag{
+					Name:  "rm-azure-kv",
+					Usage: "remove the provided comma-separated list of Azure Key Vault key URLs from the list of master keys on the given file",
+				},
+				cli.StringFlag{
+					Name:  "add-kms",
+					Usage: "add the provided comma-separated list of KMS ARNs to the list of master keys on the given file",
+				},
+				cli.StringFlag{
+					Name:  "rm-kms",
+					Usage: "remove the provided comma-separated list of KMS ARNs from the list of master keys on the given file",
+				},
+				cli.StringFlag{
+					Name:  "add-hc-vault-transit",
+					Usage: "add the provided comma-separated list of Vault's URI key to the list of master keys on the given file ( eg. https://vault.example.org:8200/v1/transit/keys/dev)",
+				},
+				cli.StringFlag{
+					Name:  "rm-hc-vault-transit",
+					Usage: "remove the provided comma-separated list of Vault's URI key from the list of master keys on the given file ( eg. https://vault.example.org:8200/v1/transit/keys/dev)",
+				},
+				cli.StringFlag{
+					Name:  "add-age",
+					Usage: "add the provided comma-separated list of age recipients fingerprints to the list of master keys on the given file",
+				},
+				cli.StringFlag{
+					Name:  "rm-age",
+					Usage: "remove the provided comma-separated list of age recipients from the list of master keys on the given file",
+				},
+				cli.StringFlag{
+					Name:  "add-pgp",
+					Usage: "add the provided comma-separated list of PGP fingerprints to the list of master keys on the given file",
+				},
+				cli.StringFlag{
+					Name:  "rm-pgp",
+					Usage: "remove the provided comma-separated list of PGP fingerprints from the list of master keys on the given file",
+				},
+				cli.StringFlag{
+					Name:  "filename-override",
+					Usage: "Use this filename instead of the provided argument for loading configuration, and for determining input type and output type",
+				},
+				cli.StringFlag{
+					Name:   "decryption-order",
+					Usage:  "comma separated list of decryption key types",
+					EnvVar: "SOPS_DECRYPTION_ORDER",
+				},
+			}, keyserviceFlags...),
+			Action: func(c *cli.Context) error {
+				if c.Bool("verbose") {
+					logging.SetLevel(logrus.DebugLevel)
+				}
+				if c.NArg() < 1 {
+					return common.NewExitError("Error: no file specified", codes.NoFileSpecified)
+				}
+				warnMoreThanOnePositionalArgument(c)
+				if c.Bool("in-place") && c.String("output") != "" {
+					return common.NewExitError("Error: cannot operate on both --output and --in-place", codes.ErrorConflictingParameters)
+				}
+				fileName, err := filepath.Abs(c.Args()[0])
+				if err != nil {
+					return toExitError(err)
+				}
+				if _, err := os.Stat(fileName); os.IsNotExist(err) {
+					if c.String("add-kms") != "" || c.String("add-pgp") != "" || c.String("add-gcp-kms") != "" || c.String("add-hc-vault-transit") != "" || c.String("add-azure-kv") != "" || c.String("add-age") != "" ||
+						c.String("rm-kms") != "" || c.String("rm-pgp") != "" || c.String("rm-gcp-kms") != "" || c.String("rm-hc-vault-transit") != "" || c.String("rm-azure-kv") != "" || c.String("rm-age") != "" {
+						return common.NewExitError("Error: cannot add or remove keys on non-existent files, use the `edit` subcommand instead.", codes.CannotChangeKeysFromNonExistentFile)
+					}
+				}
+				fileNameOverride := c.String("filename-override")
+				if fileNameOverride == "" {
+					fileNameOverride = fileName
+				}
+
+				inputStore := inputStore(c, fileNameOverride)
+				outputStore := outputStore(c, fileNameOverride)
+				svcs := keyservices(c)
+
+				order, err := decryptionOrder(c.String("decryption-order"))
+				if err != nil {
+					return toExitError(err)
+				}
+
+				rotateOpts, err := getRotateOpts(c, fileName, inputStore, outputStore, svcs, order)
+				if err != nil {
+					return toExitError(err)
+				}
+				output, err := rotate(rotateOpts)
+				if err != nil {
+					return toExitError(err)
+				}
+
+				// We open the file *after* the operations on the tree have been
+				// executed to avoid truncating it when there's errors
+				if c.Bool("in-place") {
+					file, err := os.Create(fileName)
+					if err != nil {
+						return common.NewExitError(fmt.Sprintf("Could not open in-place file for writing: %s", err), codes.CouldNotWriteOutputFile)
+					}
+					defer file.Close()
+					_, err = file.Write(output)
+					if err != nil {
+						return toExitError(err)
+					}
+					log.Info("File written successfully")
+					return nil
+				}
+
+				outputFile := os.Stdout
+				if c.String("output") != "" {
+					file, err := os.Create(c.String("output"))
+					if err != nil {
+						return common.NewExitError(fmt.Sprintf("Could not open output file for writing: %s", err), codes.CouldNotWriteOutputFile)
+					}
+					defer file.Close()
+					outputFile = file
+				}
+				_, err = outputFile.Write(output)
+				return toExitError(err)
+			},
+		},
+		{
+			Name:      "edit",
+			Usage:     "edit an encrypted file",
+			ArgsUsage: `file`,
+			Flags: append([]cli.Flag{
+				cli.StringFlag{
+					Name:   "kms, k",
+					Usage:  "comma separated list of KMS ARNs",
+					EnvVar: "SOPS_KMS_ARN",
+				},
+				cli.StringFlag{
+					Name:  "aws-profile",
+					Usage: "The AWS profile to use for requests to AWS",
+				},
+				cli.StringFlag{
+					Name:   "gcp-kms",
+					Usage:  "comma separated list of GCP KMS resource IDs",
+					EnvVar: "SOPS_GCP_KMS_IDS",
+				},
+				cli.StringFlag{
+					Name:   "azure-kv",
+					Usage:  "comma separated list of Azure Key Vault URLs",
+					EnvVar: "SOPS_AZURE_KEYVAULT_URLS",
+				},
+				cli.StringFlag{
+					Name:   "hc-vault-transit",
+					Usage:  "comma separated list of vault's key URI (e.g. 'https://vault.example.org:8200/v1/transit/keys/dev')",
+					EnvVar: "SOPS_VAULT_URIS",
+				},
+				cli.StringFlag{
+					Name:   "pgp, p",
+					Usage:  "comma separated list of PGP fingerprints",
+					EnvVar: "SOPS_PGP_FP",
+				},
+				cli.StringFlag{
+					Name:   "age, a",
+					Usage:  "comma separated list of age recipients",
+					EnvVar: "SOPS_AGE_RECIPIENTS",
+				},
+				cli.StringFlag{
+					Name:  "input-type",
+					Usage: "currently json, yaml, dotenv and binary are supported. If not set, sops will use the file's extension to determine the type",
+				},
+				cli.StringFlag{
+					Name:  "output-type",
+					Usage: "currently json, yaml, dotenv and binary are supported. If not set, sops will use the input file's extension to determine the output format",
+				},
+				cli.StringFlag{
+					Name:  "unencrypted-suffix",
+					Usage: "override the unencrypted key suffix.",
+				},
+				cli.StringFlag{
+					Name:  "encrypted-suffix",
+					Usage: "override the encrypted key suffix. When empty, all keys will be encrypted, unless otherwise marked with unencrypted-suffix.",
+				},
+				cli.StringFlag{
+					Name:  "unencrypted-regex",
+					Usage: "set the unencrypted key regex. When specified, only keys matching the regex will be left unencrypted.",
+				},
+				cli.StringFlag{
+					Name:  "encrypted-regex",
+					Usage: "set the encrypted key regex. When specified, only keys matching the regex will be encrypted.",
+				},
+				cli.StringFlag{
+					Name:  "encryption-context",
+					Usage: "comma separated list of KMS encryption context key:value pairs",
+				},
+				cli.IntFlag{
+					Name:  "shamir-secret-sharing-threshold",
+					Usage: "the number of master keys required to retrieve the data key with shamir",
+				},
+				cli.BoolFlag{
+					Name:  "show-master-keys, s",
+					Usage: "display master encryption keys in the file during editing",
+				},
+				cli.BoolFlag{
+					Name:  "ignore-mac",
+					Usage: "ignore Message Authentication Code during decryption",
+				},
+				cli.StringFlag{
+					Name:   "decryption-order",
+					Usage:  "comma separated list of decryption key types",
+					EnvVar: "SOPS_DECRYPTION_ORDER",
+				},
+			}, keyserviceFlags...),
+			Action: func(c *cli.Context) error {
+				if c.Bool("verbose") {
+					logging.SetLevel(logrus.DebugLevel)
+				}
+				if c.NArg() < 1 {
+					return common.NewExitError("Error: no file specified", codes.NoFileSpecified)
+				}
+				warnMoreThanOnePositionalArgument(c)
+				fileName, err := filepath.Abs(c.Args()[0])
+				if err != nil {
+					return toExitError(err)
+				}
+				if _, err := os.Stat(fileName); os.IsNotExist(err) {
+					return common.NewExitError("Error: cannot operate on non-existent file", codes.NoFileSpecified)
+				}
+
+				inputStore := inputStore(c, fileName)
+				outputStore := outputStore(c, fileName)
+				svcs := keyservices(c)
+
+				order, err := decryptionOrder(c.String("decryption-order"))
+				if err != nil {
+					return toExitError(err)
+				}
+				var output []byte
+				_, statErr := os.Stat(fileName)
+				fileExists := statErr == nil
+				opts := editOpts{
+					OutputStore:     outputStore,
+					InputStore:      inputStore,
+					InputPath:       fileName,
+					Cipher:          aes.NewCipher(),
+					KeyServices:     svcs,
+					DecryptionOrder: order,
+					IgnoreMAC:       c.Bool("ignore-mac"),
+					ShowMasterKeys:  c.Bool("show-master-keys"),
+				}
+				if fileExists {
+					output, err = edit(opts)
+					if err != nil {
+						return toExitError(err)
+					}
+				} else {
+					// File doesn't exist, edit the example file instead
+					encConfig, err := getEncryptConfig(c, fileName)
+					if err != nil {
+						return toExitError(err)
+					}
+					output, err = editExample(editExampleOpts{
+						editOpts:      opts,
+						encryptConfig: encConfig,
+					})
+					if err != nil {
+						return toExitError(err)
+					}
+				}
+
+				// We open the file *after* the operations on the tree have been
+				// executed to avoid truncating it when there's errors
+				file, err := os.Create(fileName)
+				if err != nil {
+					return common.NewExitError(fmt.Sprintf("Could not open in-place file for writing: %s", err), codes.CouldNotWriteOutputFile)
+				}
+				defer file.Close()
+				_, err = file.Write(output)
+				if err != nil {
+					return toExitError(err)
+				}
+				log.Info("File written successfully")
+				return nil
+			},
+		},
+		{
+			Name:      "set",
+			Usage:     `set a specific key or branch in the input document. value must be a json encoded string. eg. '/path/to/file ["somekey"][0] {"somevalue":true}'`,
+			ArgsUsage: `file index value`,
+			Flags: append([]cli.Flag{
+				cli.StringFlag{
+					Name:  "input-type",
+					Usage: "currently json, yaml, dotenv and binary are supported. If not set, sops will use the file's extension to determine the type",
+				},
+				cli.StringFlag{
+					Name:  "output-type",
+					Usage: "currently json, yaml, dotenv and binary are supported. If not set, sops will use the input file's extension to determine the output format",
+				},
+				cli.IntFlag{
+					Name:  "shamir-secret-sharing-threshold",
+					Usage: "the number of master keys required to retrieve the data key with shamir",
+				},
+				cli.BoolFlag{
+					Name:  "ignore-mac",
+					Usage: "ignore Message Authentication Code during decryption",
+				},
+				cli.StringFlag{
+					Name:   "decryption-order",
+					Usage:  "comma separated list of decryption key types",
+					EnvVar: "SOPS_DECRYPTION_ORDER",
+				},
+			}, keyserviceFlags...),
+			Action: func(c *cli.Context) error {
+				if c.Bool("verbose") {
+					logging.SetLevel(logrus.DebugLevel)
+				}
+				if c.NArg() != 3 {
+					return common.NewExitError("Error: no file specified, or index and value are missing", codes.NoFileSpecified)
+				}
+				fileName, err := filepath.Abs(c.Args()[0])
+				if err != nil {
+					return toExitError(err)
+				}
+
+				inputStore := inputStore(c, fileName)
+				outputStore := outputStore(c, fileName)
+				svcs := keyservices(c)
+
+				path, err := parseTreePath(c.Args()[1])
+				if err != nil {
+					return common.NewExitError("Invalid set index format", codes.ErrorInvalidSetFormat)
+				}
+
+				value, err := jsonValueToTreeInsertableValue(c.Args()[2])
+				if err != nil {
+					return toExitError(err)
+				}
+
+				order, err := decryptionOrder(c.String("decryption-order"))
+				if err != nil {
+					return toExitError(err)
+				}
+				output, err := set(setOpts{
+					OutputStore:     outputStore,
+					InputStore:      inputStore,
+					InputPath:       fileName,
+					Cipher:          aes.NewCipher(),
+					KeyServices:     svcs,
+					DecryptionOrder: order,
+					IgnoreMAC:       c.Bool("ignore-mac"),
+					Value:           value,
+					TreePath:        path,
+				})
+				if err != nil {
+					return toExitError(err)
+				}
+
+				// We open the file *after* the operations on the tree have been
+				// executed to avoid truncating it when there's errors
+				file, err := os.Create(fileName)
+				if err != nil {
+					return common.NewExitError(fmt.Sprintf("Could not open in-place file for writing: %s", err), codes.CouldNotWriteOutputFile)
+				}
+				defer file.Close()
+				_, err = file.Write(output)
+				if err != nil {
+					return toExitError(err)
+				}
+				log.Info("File written successfully")
+				return nil
+			},
+		},
 	}
 	app.Flags = append([]cli.Flag{
 		cli.BoolFlag{

--- a/examples/all_in_one/README.rst
+++ b/examples/all_in_one/README.rst
@@ -42,7 +42,7 @@ In both development and production, we will be storing the secrets file unencryp
 
 As peace of mind, think about this:
 
-- Unencrypted on disk is fine because if the attacker ever gains access to the server, then they can run ``sops --decrypt`` as well.
+- Unencrypted on disk is fine because if the attacker ever gains access to the server, then they can run ``sops decrypt`` as well.
 
 Files
 -----
@@ -69,7 +69,7 @@ For testing in a public CI, we can copy ``secret.enc.json`` to ``secret.json``. 
 
 ..
 
-    For convenience, we can run ``CONFIG_COPY_ONLY=TRUE bin/decrypt-config.sh`` which will use ``cp`` rather than ``sops --decrypt``.
+    For convenience, we can run ``CONFIG_COPY_ONLY=TRUE bin/decrypt-config.sh`` which will use ``cp`` rather than ``sops decrypt``.
 
 For testing in a private CI where we need private information, see the `Production instructions <#production>`_.
 

--- a/examples/all_in_one/bin/decrypt-config.sh
+++ b/examples/all_in_one/bin/decrypt-config.sh
@@ -17,6 +17,6 @@ for file in $secret_files; do
     cp "$src_file" "$target_file"
   # Otherwise, decrypt it
   else
-    sops --decrypt "$src_file" > "$target_file"
+    sops decrypt "$src_file" > "$target_file"
   fi
 done

--- a/examples/per_file/README.rst
+++ b/examples/per_file/README.rst
@@ -47,7 +47,7 @@ In both development and production, we will be storing the secrets file unencryp
 
 As peace of mind, think about this:
 
-- Unencrypted on disk is fine because if the attacker ever gains access to the server, then they can run ``sops --decrypt`` as well.
+- Unencrypted on disk is fine because if the attacker ever gains access to the server, then they can run ``sops decrypt`` as well.
 
 Files
 -----
@@ -78,7 +78,7 @@ For testing in a public CI, we can copy ``config.enc`` to ``config``. The secret
 
 ..
 
-    For convenience, we can run ``CONFIG_COPY_ONLY=TRUE bin/decrypt-config.sh`` which will use ``ln -s`` rather than ``sops --decrypt``.
+    For convenience, we can run ``CONFIG_COPY_ONLY=TRUE bin/decrypt-config.sh`` which will use ``ln -s`` rather than ``sops decrypt``.
 
 For testing in a private CI where we need private information, see the `Production instructions <#production>`_.
 

--- a/examples/per_file/bin/decrypt-config.sh
+++ b/examples/per_file/bin/decrypt-config.sh
@@ -25,7 +25,7 @@ for src_file in config.enc/*; do
   # If the file is our secret, then decrypt it
   if echo "$src_filename" | grep -E "${secret_ext}$" &&
       test "$CONFIG_COPY_ONLY" != "TRUE"; then
-    sops --decrypt "$src_file" > "$target_file"
+    sops decrypt "$src_file" > "$target_file"
   # Otherwise, symlink to the original file
   else
     ln -s "../$src_file" "$target_file"

--- a/functional-tests/src/lib.rs
+++ b/functional-tests/src/lib.rs
@@ -267,9 +267,10 @@ bar: baz",
             "sops didn't exit successfully"
         );
         let output = Command::new(SOPS_BINARY_PATH)
-            .arg("--set")
-            .arg(r#"["a"] {"aa": "aaa"}"#)
+            .arg("set")
             .arg(file_path.clone())
+            .arg(r#"["a"]"#)
+            .arg(r#"{"aa": "aaa"}"#)
             .output()
             .expect("Error running sops");
         assert!(output.status.success(), "sops didn't exit successfully");
@@ -310,9 +311,10 @@ bar: baz",
             "sops didn't exit successfully"
         );
         let output = Command::new(SOPS_BINARY_PATH)
-            .arg("--set")
-            .arg(r#"["c"] {"cc": "ccc"}"#)
+            .arg("set")
             .arg(file_path.clone())
+            .arg(r#"["c"]"#)
+            .arg(r#"{"cc": "ccc"}"#)
             .output()
             .expect("Error running sops");
         assert!(output.status.success(), "sops didn't exit successfully");
@@ -357,9 +359,10 @@ b: ba"#
             "sops didn't exit successfully"
         );
         let output = Command::new(SOPS_BINARY_PATH)
-            .arg("--set")
-            .arg(r#"["a"] {"aa": "aaa"}"#)
+            .arg("set")
             .arg(file_path.clone())
+            .arg(r#"["a"]"#)
+            .arg(r#"{"aa": "aaa"}"#)
             .output()
             .expect("Error running sops");
         assert!(output.status.success(), "sops didn't exit successfully");
@@ -404,9 +407,10 @@ b: ba"#
             "sops didn't exit successfully"
         );
         let output = Command::new(SOPS_BINARY_PATH)
-            .arg("--set")
-            .arg(r#"["c"] {"cc": "ccc"}"#)
+            .arg("set")
             .arg(file_path.clone())
+            .arg(r#"["c"]"#)
+            .arg(r#"{"cc": "ccc"}"#)
             .output()
             .expect("Error running sops");
         assert!(output.status.success(), "sops didn't exit successfully");
@@ -452,10 +456,10 @@ b: ba"#
         );
         assert!(
             Command::new(SOPS_BINARY_PATH)
-                .arg("--set")
-                .arg(r#"["a"] "aaa""#)
-                .arg("-i")
+                .arg("set")
                 .arg(file_path.clone())
+                .arg(r#"["a"]"#)
+                .arg(r#""aaa""#)
                 .output()
                 .expect("Error running sops")
                 .status


### PR DESCRIPTION
This is another Work in Progress for exploring how to implement #1333, similar to the original WIP #1343. Right now the new subcommands are basically a stripped-down copy'n'paste of the current "main" command. This PR based upon #1389, which reduces the copy'n'paste a lot.

Fixes #1333

~~This PR includes the PRs #1389 and #1390. I will rebase once these are merged.~~
