### PR TITLE
feat: improve format detection

### DIFF
--- a/cmd/sops/formats/formats.go
+++ b/cmd/sops/formats/formats.go
@@ -1,6 +1,9 @@
 package formats
 
-import "strings"
+import (
+	"path/filepath"
+	"strings"
+)
 
 // Format is an enum type
 type Format int
@@ -53,17 +56,21 @@ func IsIniFile(path string) bool {
 
 // FormatForPath returns the correct format given the path to a file
 func FormatForPath(path string) Format {
-	format := Binary // default
-	if IsYAMLFile(path) {
-		format = Yaml
-	} else if IsJSONFile(path) {
-		format = Json
-	} else if IsEnvFile(path) {
-		format = Dotenv
-	} else if IsIniFile(path) {
-		format = Ini
+	if filepath.Ext(path) == "" {
+		return Binary // default to binary
 	}
-	return format
+	switch {
+	case IsYAMLFile(path):
+		return Yaml
+	case IsJSONFile(path):
+		return Json
+	case IsEnvFile(path):
+		return Dotenv
+	case IsIniFile(path):
+		return Ini
+	default:
+		return FormatForPath(strings.TrimSuffix(path, filepath.Ext(path)))
+	}
 }
 
 // FormatForPathOrString returns the correct format-specific implementation


### PR DESCRIPTION
A common convention among sops users is to add `.enc` to the end of a file that's just been encrypted (mainly through a script of some sort; e.g. `sops -e [file].yaml > [file].yaml.enc`). Doing this causes an issue when trying to decrypt it: `sops -d [file].yaml.enc > [file].yaml`. Sops will error out when doing this because now the input and output types are to binary as the default unless you specify `--input-type` and `--output-type`. That's all well and good, but:

1. I shouldn't have to do this.
2. Not all encrypted files are going to have `.yaml`/`.yml` extensions, otherwise all sops commands could just set `--input-type` and `--output-type` and forget about it.

This PR adds a small quality of life improvement to sops that checks all the file extensions with binary as the default.