### PR TITLE
exec-file: if `--filename` is used, use the provided filename without random suffix

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -237,7 +237,7 @@ func main() {
 				},
 				cli.StringFlag{
 					Name:  "filename",
-					Usage: "filename for the temporarily file (default: tmp-file)",
+					Usage: fmt.Sprintf("filename for the temporarily file (default: %s)", exec.FallbackFilename),
 				},
 			}, keyserviceFlags...),
 			Action: func(c *cli.Context) error {
@@ -272,11 +272,6 @@ func main() {
 					return toExitError(err)
 				}
 
-				filename := c.String("filename")
-				if filename == "" {
-					filename = "tmp-file"
-				}
-
 				if c.Bool("background") {
 					log.Warn("exec-file's --background option is deprecated and will be removed in a future version of sops")
 				}
@@ -287,7 +282,7 @@ func main() {
 					Background: c.Bool("background"),
 					Fifo:       !c.Bool("no-fifo"),
 					User:       c.String("user"),
-					Filename:   filename,
+					Filename:   c.String("filename"),
 				}); err != nil {
 					return toExitError(err)
 				}

--- a/functional-tests/src/lib.rs
+++ b/functional-tests/src/lib.rs
@@ -949,4 +949,47 @@ bar: |-
 }"#
         );
     }
+
+    #[test]
+    fn exec_file_filename() {
+        let file_path = prepare_temp_file(
+            "test_exec_file_filename.yaml",
+            r#"foo: bar
+bar: |-
+  baz
+  bam
+"#
+            .as_bytes(),
+        );
+        assert!(
+            Command::new(SOPS_BINARY_PATH)
+                .arg("-e")
+                .arg("-i")
+                .arg(file_path.clone())
+                .output()
+                .expect("Error running sops")
+                .status
+                .success(),
+            "sops didn't exit successfully"
+        );
+        let output = Command::new(SOPS_BINARY_PATH)
+            .arg("exec-file")
+            .arg("--no-fifo")
+            .arg("--filename")
+            .arg("foobar")
+            .arg(file_path.clone())
+            .arg("echo {}")
+            .output()
+            .expect("Error running sops");
+        assert!(output.status.success(), "sops didn't exit successfully");
+        println!(
+            "stdout: {}, stderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stdout).ends_with("foobar\n"),
+            "filename did not end with 'foobar'"
+        );
+    }
 }


### PR DESCRIPTION
Fixes #1473.