### PR TITLE
add command unset

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1471,6 +1471,25 @@ The value must be formatted as json.
 
     $ sops set ~/git/svc/sops/example.yaml '["an_array"][1]' '{"uid1":null,"uid2":1000,"uid3":["bob"]}'
 
+Unset a sub-part in a document tree
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Symmetrically, SOPS can unset a specific part of a YAML or JSON document, by providing
+the path in the ``unset`` command. This is useful to unset specific values, like keys, without
+needing an editor.
+
+.. code:: sh
+
+    $ sops unset ~/git/svc/sops/example.yaml '["app2"]["key"]'
+
+The tree path syntax uses regular python dictionary syntax, without the
+variable name. Set to keys by naming them, and array elements by
+numbering them.
+
+.. code:: sh
+
+    $ sops unset ~/git/svc/sops/example.yaml '["an_array"][1]'
+
 Showing diffs in cleartext in git
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -1349,6 +1349,87 @@ func main() {
 				return nil
 			},
 		},
+		{
+			Name:      "unset",
+			Usage:     `unset a specific key or branch in the input document.`,
+			ArgsUsage: `file index`,
+			Flags: append([]cli.Flag{
+				cli.StringFlag{
+					Name:  "input-type",
+					Usage: "currently json, yaml, dotenv and binary are supported. If not set, sops will use the file's extension to determine the type",
+				},
+				cli.StringFlag{
+					Name:  "output-type",
+					Usage: "currently json, yaml, dotenv and binary are supported. If not set, sops will use the input file's extension to determine the output format",
+				},
+				cli.IntFlag{
+					Name:  "shamir-secret-sharing-threshold",
+					Usage: "the number of master keys required to retrieve the data key with shamir",
+				},
+				cli.BoolFlag{
+					Name:  "ignore-mac",
+					Usage: "ignore Message Authentication Code during decryption",
+				},
+				cli.StringFlag{
+					Name:   "decryption-order",
+					Usage:  "comma separated list of decryption key types",
+					EnvVar: "SOPS_DECRYPTION_ORDER",
+				},
+			}, keyserviceFlags...),
+			Action: func(c *cli.Context) error {
+				if c.Bool("verbose") {
+					logging.SetLevel(logrus.DebugLevel)
+				}
+				if c.NArg() != 2 {
+					return common.NewExitError("Error: no file specified, or index is missing", codes.NoFileSpecified)
+				}
+				fileName, err := filepath.Abs(c.Args()[0])
+				if err != nil {
+					return toExitError(err)
+				}
+
+				inputStore := inputStore(c, fileName)
+				outputStore := outputStore(c, fileName)
+				svcs := keyservices(c)
+
+				path, err := parseTreePath(c.Args()[1])
+				if err != nil {
+					return common.NewExitError("Invalid unset index format", codes.ErrorInvalidSetFormat)
+				}
+
+				order, err := decryptionOrder(c.String("decryption-order"))
+				if err != nil {
+					return toExitError(err)
+				}
+				output, err := unset(unsetOpts{
+					OutputStore:     outputStore,
+					InputStore:      inputStore,
+					InputPath:       fileName,
+					Cipher:          aes.NewCipher(),
+					KeyServices:     svcs,
+					DecryptionOrder: order,
+					IgnoreMAC:       c.Bool("ignore-mac"),
+					TreePath:        path,
+				})
+				if err != nil {
+					return toExitError(err)
+				}
+
+				// We open the file *after* the operations on the tree have been
+				// executed to avoid truncating it when there's errors
+				file, err := os.Create(fileName)
+				if err != nil {
+					return common.NewExitError(fmt.Sprintf("Could not open in-place file for writing: %s", err), codes.CouldNotWriteOutputFile)
+				}
+				defer file.Close()
+				_, err = file.Write(output)
+				if err != nil {
+					return toExitError(err)
+				}
+				log.Info("File written successfully")
+				return nil
+			},
+		},
 	}
 	app.Flags = append([]cli.Flag{
 		cli.BoolFlag{

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -1375,6 +1375,10 @@ func main() {
 					Usage:  "comma separated list of decryption key types",
 					EnvVar: "SOPS_DECRYPTION_ORDER",
 				},
+				cli.BoolFlag{
+					Name:   "idempotent",
+					Usage:  "do nothing if the given index does not exist",
+				},
 			}, keyserviceFlags...),
 			Action: func(c *cli.Context) error {
 				if c.Bool("verbose") {
@@ -1412,6 +1416,9 @@ func main() {
 					TreePath:        path,
 				})
 				if err != nil {
+					if _, ok := err.(*sops.SopsKeyNotFound); ok && c.Bool("idempotent") {
+						return nil
+					}
 					return toExitError(err)
 				}
 

--- a/cmd/sops/unset.go
+++ b/cmd/sops/unset.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/getsops/sops/v3"
+	"github.com/getsops/sops/v3/cmd/sops/codes"
+	"github.com/getsops/sops/v3/cmd/sops/common"
+	"github.com/getsops/sops/v3/keyservice"
+)
+
+type unsetOpts struct {
+	Cipher          sops.Cipher
+	InputStore      sops.Store
+	OutputStore     sops.Store
+	InputPath       string
+	IgnoreMAC       bool
+	TreePath        []interface{}
+	KeyServices     []keyservice.KeyServiceClient
+	DecryptionOrder []string
+}
+
+func unset(opts unsetOpts) ([]byte, error) {
+	// Load the file
+	// TODO: Issue #173: if the file does not exist, create it with the contents passed in as opts.Value
+	tree, err := common.LoadEncryptedFileWithBugFixes(common.GenericDecryptOpts{
+		Cipher:      opts.Cipher,
+		InputStore:  opts.InputStore,
+		InputPath:   opts.InputPath,
+		IgnoreMAC:   opts.IgnoreMAC,
+		KeyServices: opts.KeyServices,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Decrypt the file
+	dataKey, err := common.DecryptTree(common.DecryptTreeOpts{
+		Cipher:          opts.Cipher,
+		IgnoreMac:       opts.IgnoreMAC,
+		Tree:            tree,
+		KeyServices:     opts.KeyServices,
+		DecryptionOrder: opts.DecryptionOrder,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Unset the value
+	newBranch, err := tree.Branches[0].Unset(opts.TreePath)
+	if err != nil {
+		return nil, err
+	}
+	tree.Branches[0] = newBranch
+
+	err = common.EncryptTree(common.EncryptTreeOpts{
+		DataKey: dataKey, Tree: tree, Cipher: opts.Cipher,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	encryptedFile, err := opts.OutputStore.EmitEncryptedFile(*tree)
+	if err != nil {
+		return nil, common.NewExitError(fmt.Sprintf("Could not marshal tree: %s", err), codes.ErrorDumpingTree)
+	}
+	return encryptedFile, err
+}

--- a/cmd/sops/unset.go
+++ b/cmd/sops/unset.go
@@ -22,7 +22,6 @@ type unsetOpts struct {
 
 func unset(opts unsetOpts) ([]byte, error) {
 	// Load the file
-	// TODO: Issue #173: if the file does not exist, create it with the contents passed in as opts.Value
 	tree, err := common.LoadEncryptedFileWithBugFixes(common.GenericDecryptOpts{
 		Cipher:      opts.Cipher,
 		InputStore:  opts.InputStore,

--- a/functional-tests/src/lib.rs
+++ b/functional-tests/src/lib.rs
@@ -273,12 +273,12 @@ bar: baz",
             .arg(r#"{"aa": "aaa"}"#)
             .output()
             .expect("Error running sops");
-        assert!(output.status.success(), "sops didn't exit successfully");
         println!(
             "stdout: {}, stderr: {}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
+        assert!(output.status.success(), "sops didn't exit successfully");
         let mut s = String::new();
         File::open(file_path)
             .unwrap()
@@ -317,12 +317,12 @@ bar: baz",
             .arg(r#"{"cc": "ccc"}"#)
             .output()
             .expect("Error running sops");
-        assert!(output.status.success(), "sops didn't exit successfully");
         println!(
             "stdout: {}, stderr: {}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
+        assert!(output.status.success(), "sops didn't exit successfully");
         let mut s = String::new();
         File::open(file_path)
             .unwrap()
@@ -365,12 +365,12 @@ b: ba"#
             .arg(r#"{"aa": "aaa"}"#)
             .output()
             .expect("Error running sops");
-        assert!(output.status.success(), "sops didn't exit successfully");
         println!(
             "stdout: {}, stderr: {}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
+        assert!(output.status.success(), "sops didn't exit successfully");
         let mut s = String::new();
         File::open(file_path)
             .unwrap()
@@ -413,12 +413,12 @@ b: ba"#
             .arg(r#"{"cc": "ccc"}"#)
             .output()
             .expect("Error running sops");
-        assert!(output.status.success(), "sops didn't exit successfully");
         println!(
             "stdout: {}, stderr: {}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
+        assert!(output.status.success(), "sops didn't exit successfully");
         let mut s = String::new();
         File::open(file_path)
             .unwrap()
@@ -472,12 +472,12 @@ b: ba"#
             .arg(file_path.clone())
             .output()
             .expect("Error running sops");
-        assert!(output.status.success(), "sops didn't exit successfully");
         println!(
             "stdout: {}, stderr: {}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
+        assert!(output.status.success(), "sops didn't exit successfully");
         let mut s = String::new();
         File::open(file_path)
             .unwrap()
@@ -529,12 +529,12 @@ b: ba"#
             .arg(file_path.clone())
             .output()
             .expect("Error running sops");
-        assert!(output.status.success(), "sops didn't exit successfully");
         println!(
             "stdout: {}, stderr: {}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
+        assert!(output.status.success(), "sops didn't exit successfully");
         let mut s = String::new();
         File::open(file_path)
             .unwrap()
@@ -571,12 +571,12 @@ b: ba"#
             .arg(r#"["a"]"#)
             .output()
             .expect("Error running sops");
-        assert!(output.status.success(), "sops didn't exit successfully");
         println!(
             "stdout: {}, stderr: {}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
+        assert!(output.status.success(), "sops didn't exit successfully");
         let mut content = String::new();
         File::open(file_path.clone())
             .unwrap()
@@ -598,12 +598,12 @@ b: ba"#
             .arg(r#"["a"]"#)
             .output()
             .expect("Error running sops");
-        assert!(output.status.success(), "sops didn't exit successfully");
         println!(
             "stdout: {}, stderr: {}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
+        assert!(output.status.success(), "sops didn't exit successfully");
         let mut idempotent_content = String::new();
         File::open(file_path.clone())
             .unwrap()
@@ -618,12 +618,12 @@ b: ba"#
             .arg(r#"["c"][1]"#)
             .output()
             .expect("Error running sops");
-        assert!(output.status.success(), "sops didn't exit successfully");
         println!(
             "stdout: {}, stderr: {}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
+        assert!(output.status.success(), "sops didn't exit successfully");
         let mut content = String::new();
         File::open(file_path.clone())
             .unwrap()
@@ -644,12 +644,12 @@ b: ba"#
             .arg(r#"["c"][1]"#)
             .output()
             .expect("Error running sops");
-        assert!(output.status.success(), "sops didn't exit successfully");
         println!(
             "stdout: {}, stderr: {}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
+        assert!(output.status.success(), "sops didn't exit successfully");
         let mut idempotent_content = String::new();
         File::open(file_path.clone())
             .unwrap()
@@ -680,12 +680,12 @@ b: ba"#
             .arg(r#"["a"]"#)
             .output()
             .expect("Error running sops");
-        assert!(output.status.success(), "sops didn't exit successfully");
         println!(
             "stdout: {}, stderr: {}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
+        assert!(output.status.success(), "sops didn't exit successfully");
         let mut content = String::new();
         File::open(file_path.clone())
             .unwrap()
@@ -707,12 +707,12 @@ b: ba"#
             .arg(r#"["a"]"#)
             .output()
             .expect("Error running sops");
-        assert!(output.status.success(), "sops didn't exit successfully");
         println!(
             "stdout: {}, stderr: {}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
+        assert!(output.status.success(), "sops didn't exit successfully");
         let mut idempotent_content = String::new();
         File::open(file_path.clone())
             .unwrap()
@@ -727,12 +727,12 @@ b: ba"#
             .arg(r#"["c"][0]"#)
             .output()
             .expect("Error running sops");
-        assert!(output.status.success(), "sops didn't exit successfully");
         println!(
             "stdout: {}, stderr: {}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
+        assert!(output.status.success(), "sops didn't exit successfully");
         let mut content = String::new();
         File::open(file_path.clone())
             .unwrap()
@@ -753,12 +753,12 @@ b: ba"#
             .arg(r#"["c"][1]"#)
             .output()
             .expect("Error running sops");
-        assert!(output.status.success(), "sops didn't exit successfully");
         println!(
             "stdout: {}, stderr: {}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
+        assert!(output.status.success(), "sops didn't exit successfully");
         let mut idempotent_content = String::new();
         File::open(file_path.clone())
             .unwrap()
@@ -1094,12 +1094,12 @@ echo -E "${foo}"
             .arg(format!("/bin/bash {}", print_foo))
             .output()
             .expect("Error running sops");
-        assert!(output.status.success(), "sops didn't exit successfully");
         println!(
             "stdout: {}, stderr: {}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
+        assert!(output.status.success(), "sops didn't exit successfully");
         assert_eq!(String::from_utf8_lossy(&output.stdout), "bar\n");
         let print_bar = prepare_temp_file(
             "print_bar.sh",
@@ -1114,12 +1114,12 @@ echo -E "${bar}"
             .arg(format!("/bin/bash {}", print_bar))
             .output()
             .expect("Error running sops");
-        assert!(output.status.success(), "sops didn't exit successfully");
         println!(
             "stdout: {}, stderr: {}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
+        assert!(output.status.success(), "sops didn't exit successfully");
         assert_eq!(String::from_utf8_lossy(&output.stdout), "baz\nbam\n");
     }
 
@@ -1153,12 +1153,12 @@ bar: |-
             .arg("cat {}")
             .output()
             .expect("Error running sops");
-        assert!(output.status.success(), "sops didn't exit successfully");
         println!(
             "stdout: {}, stderr: {}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
+        assert!(output.status.success(), "sops didn't exit successfully");
         assert_eq!(
             String::from_utf8_lossy(&output.stdout),
             r#"{


### PR DESCRIPTION
Add an `unset` command to remove a key or item from the file.

Fixes #1305.

I'm not familiar with Go or Rust, so I mainly adapted what was already present in the `set` command.