### PR TITLE
fix(Makefile): set locale to make tests pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ checkmd: $(MD_FILES)
 .PHONY: test
 test: vendor
 	gpg --import pgp/sops_functional_tests_key.asc 2>&1 1>/dev/null || exit 0
-	$(GO) test $(GO_TEST_FLAGS) ./...
+	LANG=en_US.UTF-8 $(GO) test $(GO_TEST_FLAGS) ./...
 
 .PHONY: showcoverage
 showcoverage: test


### PR DESCRIPTION
Matching on error messages without specifying locale failed for my German setup

<details>
<summary>Error Message</summary>

```
--- FAIL: TestGnuPGHome_Import (0.02s)                                                                                                                                                                                                                                                                                        
    keysource_test.go:71:                                                                                                                                                                                                                                                                                                     
                Error Trace:    /home/jbadstuebner/Dokumente/git/github.com/jonasbadstuebner/sops/main/pgp/keysource_test.go:71                                                                                                                                                                                               
                Error:          Error "failed to import armored key data into GnuPG keyring (exit status 2): gpg: Keine gültigen OpenPGP-Daten gefunden.\ngpg: Anzahl insgesamt bearbeiteter Schlüssel: 0" does not contain "(exit status 2): gpg: no valid OpenPGP data found.\ngpg: Total number processed: 0"              
                Test:           TestGnuPGHome_Import                                                                                                                                                                                                                                                                          
--- FAIL: TestMasterKey_encryptWithGnuPG (0.04s)                                                                                                                                                                                                                                                                              
    --- FAIL: TestMasterKey_encryptWithGnuPG/invalid_fingerprint_error (0.00s)                                                                                                                                                                                                                                                
        keysource_test.go:303:                                                                                                                                                                                                                                                                                                
                Error Trace:    /home/jbadstuebner/Dokumente/git/github.com/jonasbadstuebner/sops/main/pgp/keysource_test.go:303                                                                                                                                                                                              
                Error:          Error "failed to encrypt sops data key with pgp: gpg: 'invalid' ist keine gültige lange Schlüssel-ID" does not contain "failed to encrypt sops data key with pgp: gpg: 'invalid' is not a valid long keyID"                                                                                   
                Test:           TestMasterKey_encryptWithGnuPG/invalid_fingerprint_error                                                                                                                                                                                                                                      
--- FAIL: TestMasterKey_decryptWithGnuPG (0.04s)                                                                                                                                                                                                                                                                              
    --- FAIL: TestMasterKey_decryptWithGnuPG/invalid_data_error (0.00s)                                                                                                                                                                                                                                                       
        keysource_test.go:507:                                                                                                                                 
                Error Trace:    /home/jbadstuebner/Dokumente/git/github.com/jonasbadstuebner/sops/main/pgp/keysource_test.go:507     
                Error:          Error "failed to decrypt sops data key with pgp: gpg: Keine gültigen OpenPGP-Daten gefunden.\ngpg: decrypt_message failed: Unbekannter Systemfehler" does not contain "gpg: no valid OpenPGP data found"
                Test:           TestMasterKey_decryptWithGnuPG/invalid_data_error                                                    
FAIL
```
</details>