### PR TITLE
correct `decrypt`/`encrypt` to `-d`/`-e` in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,7 +154,7 @@ To decrypt a file in a ``cat`` fashion, use the ``-d`` flag:
 
 .. code:: sh
 
-    $ sops decrypt mynewtestfile.yaml
+    $ sops -d mynewtestfile.yaml
 
 SOPS encrypted files contain the necessary information to decrypt their content.
 All a user of SOPS needs is valid AWS credentials and the necessary
@@ -200,7 +200,7 @@ the ``--age`` option or the **SOPS_AGE_RECIPIENTS** environment variable:
 
 .. code:: sh
 
-    $ sops encrypt --age age1yt3tfqlfrwdwx0z0ynwplcr6qxcxfaqycuprpmy89nr83ltx74tqdpszlw test.yaml > test.enc.yaml
+    $ sops -e --age age1yt3tfqlfrwdwx0z0ynwplcr6qxcxfaqycuprpmy89nr83ltx74tqdpszlw test.yaml > test.enc.yaml
 
 When decrypting a file with the corresponding identity, SOPS will look for a
 text file name ``keys.txt`` located in a ``sops`` subdirectory of your user
@@ -250,11 +250,11 @@ sdk:
 
 Now you can encrypt a file using::
 
-    $ sops encrypt --gcp-kms projects/my-project/locations/global/keyRings/sops/cryptoKeys/sops-key test.yaml > test.enc.yaml
+    $ sops -e --gcp-kms projects/my-project/locations/global/keyRings/sops/cryptoKeys/sops-key test.yaml > test.enc.yaml
 
 And decrypt it using::
 
-     $ sops decrypt test.enc.yaml
+     $ sops -d test.enc.yaml
 
 Encrypting using Azure Key Vault
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -324,11 +324,11 @@ from the commandline:
 
 Now you can encrypt a file using::
 
-    $ sops encrypt --azure-kv https://sops.vault.azure.net/keys/sops-key/some-string test.yaml > test.enc.yaml
+    $ sops -e --azure-kv https://sops.vault.azure.net/keys/sops-key/some-string test.yaml > test.enc.yaml
 
 And decrypt it using::
 
-    $ sops decrypt test.enc.yaml
+    $ sops -d test.enc.yaml
 
 
 Encrypting and decrypting from other programs
@@ -344,7 +344,7 @@ To decrypt data, you can simply do:
 
 .. code:: sh
 
-	$ cat encrypted-data | sops decrypt /dev/stdin > decrypted-data
+	$ cat encrypted-data | sops -d /dev/stdin > decrypted-data
 
 To control the input and output format, pass ``--input-type`` and ``--output-type`` as appropriate. By default,
 ``sops`` determines the input and output format from the provided filename, which is ``/dev/stdin`` here, and
@@ -354,7 +354,7 @@ For example, to decrypt YAML data and obtain the decrypted result as YAML, use:
 
 .. code:: sh
 
-	$ cat encrypted-data | sops decrypt --input-type yaml --output-type yaml /dev/stdin > decrypted-data
+	$ cat encrypted-data | sops -d --input-type yaml --output-type yaml /dev/stdin > decrypted-data
 
 To encrypt, it is important to note that SOPS also uses the filename to look up the correct creation rule from
 ``.sops.yaml``. Likely ``/dev/stdin`` will not match a creation rule, or only match the fallback rule without
@@ -363,7 +363,7 @@ parameter which allows you to tell SOPS which filename to use to match creation 
 
 .. code:: sh
 
-	$ echo 'foo: bar' | sops encrypt --filename-override path/filename.sops.yaml /dev/stdin > encrypted-data
+	$ echo 'foo: bar' | sops -e --filename-override path/filename.sops.yaml /dev/stdin > encrypted-data
 
 SOPS will find a matching creation rule for ``path/filename.sops.yaml`` in ``.sops.yaml`` and use that one to
 encrypt the data from stdin. This filename will also be used to determine the input and output store. As always,
@@ -372,7 +372,7 @@ the input store type can be adjusted by passing ``--input-type``, and the output
 
 .. code:: sh
 
-	$ echo foo=bar | sops encrypt --filename-override path/filename.sops.yaml --input-type dotenv /dev/stdin > encrypted-data
+	$ echo foo=bar | sops -e --filename-override path/filename.sops.yaml --input-type dotenv /dev/stdin > encrypted-data
 
 
 Encrypting using Hashicorp Vault
@@ -423,7 +423,7 @@ To easily deploy Vault locally: (DO NOT DO THIS FOR PRODUCTION!!!)
     $ vault write sops/keys/thirdkey type=chacha20-poly1305
     Success! Data written to: sops/keys/thirdkey
 
-    $ sops encrypt --hc-vault-transit $VAULT_ADDR/v1/sops/keys/firstkey vault_example.yml
+    $ sops -e --hc-vault-transit $VAULT_ADDR/v1/sops/keys/firstkey vault_example.yml
 
     $ cat <<EOF > .sops.yaml
     creation_rules:
@@ -433,7 +433,7 @@ To easily deploy Vault locally: (DO NOT DO THIS FOR PRODUCTION!!!)
           hc_vault_transit_uri: "$VAULT_ADDR/v1/sops/keys/thirdkey"
     EOF
 
-    $ sops encrypt --verbose prod/raw.yaml > prod/encrypted.yaml
+    $ sops -e --verbose prod/raw.yaml > prod/encrypted.yaml
 
 Adding and removing keys
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -889,7 +889,7 @@ You can then decrypt the file the same way as with any other SOPS file:
 
 .. code:: sh
 
-    $ sops decrypt example.json
+    $ sops -d example.json
 
 Key service
 ~~~~~~~~~~~
@@ -929,14 +929,14 @@ service exposed on the unix socket located in ``/tmp/sops.sock``, you can run:
 
 .. code:: sh
 
-    $ sops decrypt --keyservice unix:///tmp/sops.sock file.yaml`
+    $ sops -d --keyservice unix:///tmp/sops.sock file.yaml`
 
 And if you only want to use the key service exposed on the unix socket located
 in ``/tmp/sops.sock`` and not the local key service, you can run:
 
 .. code:: sh
 
-    $ sops decrypt --enable-local-keyservice=false --keyservice unix:///tmp/sops.sock file.yaml
+    $ sops -d --enable-local-keyservice=false --keyservice unix:///tmp/sops.sock file.yaml
 
 Auditing
 ~~~~~~~~
@@ -1003,7 +1003,7 @@ written to disk.
 .. code:: sh
 
     # print secrets to stdout to confirm values
-    $ sops decrypt out.json
+    $ sops -d out.json
     {
             "database_password": "jf48t9wfw094gf4nhdf023r",
             "AWS_ACCESS_KEY_ID": "AKIAIOSFODNN7EXAMPLE",
@@ -1153,7 +1153,7 @@ Below is an example of publishing to Vault (using token auth with a local dev in
 
     $ export VAULT_TOKEN=...
     $ export VAULT_ADDR='http://127.0.0.1:8200'
-    $ sops decrypt vault/test.yaml
+    $ sops -d vault/test.yaml
     example_string: bar
     example_number: 42
     example_map:
@@ -1194,23 +1194,23 @@ extension after encrypting a file. For example:
 
 .. code:: sh
 
-    $ sops encrypt -i myfile.json
-    $ sops decrypt myfile.json
+    $ sops -e -i myfile.json
+    $ sops -d myfile.json
 
 If you want to change the extension of the file once encrypted, you need to provide
 ``sops`` with the ``--input-type`` flag upon decryption. For example:
 
 .. code:: sh
 
-    $ sops encrypt myfile.json > myfile.json.enc
+    $ sops -e myfile.json > myfile.json.enc
 
-    $ sops decrypt --input-type json myfile.json.enc
+    $ sops -d --input-type json myfile.json.enc
 
 When operating on stdin, use the ``--input-type`` and ``--output-type`` flags as follows:
 
 .. code:: sh
 
-    $ cat myfile.json | sops decrypt --input-type json --output-type json /dev/stdin
+    $ cat myfile.json | sops -d --input-type json --output-type json /dev/stdin
 
 JSON and JSON_binary indentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1362,13 +1362,13 @@ encrypt the file, and redirect the output to a destination file.
 
     $ export SOPS_KMS_ARN="arn:aws:kms:us-west-2:927034868273:key/fe86dd69-4132-404c-ab86-4269956b4500"
     $ export SOPS_PGP_FP="C9CAB0AF1165060DB58D6D6B2653B624D620786D"
-    $ sops encrypt /path/to/existing/file.yaml > /path/to/new/encrypted/file.yaml
+    $ sops -e /path/to/existing/file.yaml > /path/to/new/encrypted/file.yaml
 
 Decrypt the file with ``-d``.
 
 .. code:: sh
 
-    $ sops decrypt /path/to/new/encrypted/file.yaml
+    $ sops -d /path/to/new/encrypted/file.yaml
 
 Encrypt or decrypt a file in place
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1379,9 +1379,9 @@ original file after encrypting or decrypting it.
 .. code:: sh
 
     # file.yaml is in cleartext
-    $ sops encrypt -i /path/to/existing/file.yaml
+    $ sops -e -i /path/to/existing/file.yaml
     # file.yaml is now encrypted
-    $ sops decrypt -i /path/to/existing/file.yaml
+    $ sops -d -i /path/to/existing/file.yaml
     # file.yaml is back in cleartext
 
 Encrypting binary files
@@ -1408,10 +1408,10 @@ In-place encryption/decryption also works on binary files.
     $ sha512sum /tmp/somerandom
     9589bb20280e9d381f7a192000498c994e921b3cdb11d2ef5a986578dc2239a340b25ef30691bac72bdb14028270828dad7e8bd31e274af9828c40d216e60cbe /tmp/somerandom
 
-    $ sops encrypt -i /tmp/somerandom
+    $ sops -e -i /tmp/somerandom
     please wait while a data encryption key is being generated and stored securely
 
-    $ sops decrypt -i /tmp/somerandom
+    $ sops -d -i /tmp/somerandom
 
     $ sha512sum /tmp/somerandom
     9589bb20280e9d381f7a192000498c994e921b3cdb11d2ef5a986578dc2239a340b25ef30691bac72bdb14028270828dad7e8bd31e274af9828c40d216e60cbe /tmp/somerandom
@@ -1425,7 +1425,7 @@ values, like keys, without needing an extra parser.
 
 .. code:: sh
 
-    $ sops decrypt --extract '["app2"]["key"]' ~/git/svc/sops/example.yaml
+    $ sops -d --extract '["app2"]["key"]' ~/git/svc/sops/example.yaml
     -----BEGIN RSA PRIVATE KEY-----
     MIIBPAIBAAJBAPTMNIyHuZtpLYc7VsHQtwOkWYobkUblmHWRmbXzlAX6K8tMf3Wf
     ImcbNkqAKnELzFAPSBeEMhrBN0PyOC9lYlMCAwEAAQJBALXD4sjuBn1E7Y9aGiMz
@@ -1442,7 +1442,7 @@ them.
 
 .. code:: sh
 
-    $ sops decrypt --extract '["an_array"][1]' ~/git/svc/sops/example.yaml
+    $ sops -d --extract '["an_array"][1]' ~/git/svc/sops/example.yaml
     secretuser2
 
 Set a sub-part in a document tree
@@ -1489,11 +1489,11 @@ to a SOPS command in the git configuration file of the repository.
 
 .. code:: sh
 
-    $ git config diff.sopsdiffer.textconv "sops decrypt"
+    $ git config diff.sopsdiffer.textconv "sops -d"
 
     $ grep -A 1 sopsdiffer .git/config
     [diff "sopsdiffer"]
-        textconv = "sops decrypt"
+        textconv = "sops -d"
 
 With this in place, calls to ``git diff`` will decrypt both previous and current
 versions of the target file prior to displaying the diff. And it even works with
@@ -1528,7 +1528,7 @@ keys that match the supplied regular expression.  For example, this command:
 
 .. code:: sh
 
-    $ sops encrypt --encrypted-regex '^(data|stringData)$' k8s-secrets.yaml
+    $ sops -e --encrypted-regex '^(data|stringData)$' k8s-secrets.yaml
 
 will encrypt the values under the ``data`` and ``stringData`` keys in a YAML file
 containing kubernetes secrets.  It will not encrypt other values that help you to
@@ -1540,7 +1540,7 @@ that match the supplied regular expression. For example, this command:
 
 .. code:: sh
 
-    $ sops encrypt --unencrypted-regex '^(description|metadata)$' k8s-secrets.yaml
+    $ sops -e --unencrypted-regex '^(description|metadata)$' k8s-secrets.yaml
 
 will not encrypt the values under the ``description`` and ``metadata`` keys in a YAML file
 containing kubernetes secrets, while encrypting everything else.


### PR DESCRIPTION
The README described the use of `sops decrypt` and `sops encrypt` commands that no longer exist in modern versions.

The correct commands seem to be `sops -d` and `sops -e`.

I ran into this while trying to get the `git diff`ing working as described in this doc.