### PR TITLE
Fixing updatekeys command to respect configured shamir_threshold with groups

### DIFF
--- a/cmd/sops/common/common_test.go
+++ b/cmd/sops/common/common_test.go
@@ -1,0 +1,87 @@
+package common
+
+import (
+	"github.com/getsops/sops/v3"
+	"github.com/getsops/sops/v3/config"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDiffShamirThresholdWhenIntroducingGroupsAndThresholdBelowGroupSize(t *testing.T) {
+	metadata := sops.Metadata{ShamirThreshold: 0}
+	conf := MakeConfig(2, 3)
+	diff := DiffShamirThreshold(metadata, &conf)
+
+	assert.Equal(t, 0, diff.Old)
+	assert.Equal(t, 2, diff.New)
+}
+
+func TestDiffShamirThresholdWhenIntroducingGroupsAndThresholdAboveGroupSize(t *testing.T) {
+	metadata := sops.Metadata{ShamirThreshold: 0}
+	conf := MakeConfig(4, 3)
+	diff := DiffShamirThreshold(metadata, &conf)
+
+	assert.Equal(t, 0, diff.Old)
+	assert.Equal(t, 3, diff.New)
+}
+
+func TestDiffShamirThresholdWhenIntroducingGroupsAndNoThresholdIsConfigured(t *testing.T) {
+	metadata := sops.Metadata{ShamirThreshold: 0}
+	conf := MakeConfig(0, 3)
+	diff := DiffShamirThreshold(metadata, &conf)
+
+	assert.Equal(t, 0, diff.Old)
+	assert.Equal(t, 3, diff.New)
+}
+
+func TestDiffShamirThresholdWhenReducingThreshold(t *testing.T) {
+	metadata := sops.Metadata{ShamirThreshold: 3}
+	conf := MakeConfig(2, 3)
+	diff := DiffShamirThreshold(metadata, &conf)
+
+	assert.Equal(t, 3, diff.Old)
+	assert.Equal(t, 2, diff.New)
+}
+
+func TestDiffShamirThresholdWhenIncreasingThreshold(t *testing.T) {
+	metadata := sops.Metadata{ShamirThreshold: 2}
+	conf := MakeConfig(3, 4)
+	diff := DiffShamirThreshold(metadata, &conf)
+
+	assert.Equal(t, 2, diff.Old)
+	assert.Equal(t, 3, diff.New)
+}
+
+func TestDiffShamirThresholdWhenRemovingThresholdConfiguration(t *testing.T) {
+	metadata := sops.Metadata{ShamirThreshold: 2}
+	conf := MakeConfig(0, 4)
+	diff := DiffShamirThreshold(metadata, &conf)
+
+	assert.Equal(t, 2, diff.Old)
+	assert.Equal(t, 4, diff.New)
+}
+
+func TestDiffShamirThresholdWhenIntroducingSingleGroup(t *testing.T) {
+	metadata := sops.Metadata{ShamirThreshold: 0}
+	conf := MakeConfig(2, 1)
+	diff := DiffShamirThreshold(metadata, &conf)
+
+	assert.Equal(t, 0, diff.Old)
+	assert.Equal(t, 0, diff.New)
+}
+
+func TestDiffShamirThresholdWhenReducingToSingleGroup(t *testing.T) {
+	metadata := sops.Metadata{ShamirThreshold: 3}
+	conf := MakeConfig(2, 1)
+	diff := DiffShamirThreshold(metadata, &conf)
+
+	assert.Equal(t, 3, diff.Old)
+	assert.Equal(t, 0, diff.New)
+}
+
+func MakeConfig(shamirThreshold int, keygroups int) config.Config {
+	return config.Config{
+		ShamirThreshold: shamirThreshold,
+		KeyGroups:       make([]sops.KeyGroup, keygroups),
+	}
+}

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -593,7 +593,6 @@ func main() {
 				for _, path := range c.Args() {
 					err := updatekeys.UpdateKeys(updatekeys.Opts{
 						InputPath:   path,
-						GroupQuorum: c.Int("shamir-secret-sharing-quorum"),
 						KeyServices: keyservices(c),
 						Interactive: !c.Bool("yes"),
 						ConfigPath:  configPath,


### PR DESCRIPTION
I noticed a bug when running `sops updatekeys <filename>` after changing the `.sops.yaml` configuration from a single master key to 3 groups with master keys and a `shamir_threshold` below the groups size. The threshold configuration was not respected, and the group size was always used. There was also a problem with increasing the `shamir_threshold`. If the threshold was still below the group size, the old threshold were used.

This PR aims to solve the following issues:
- Remove the unused argument `shamir-secret-sharing-quorum`, and the related `GroupQuorum` option that was always `0` 
- Correctly respect the `shamir_threshold` defined in the configuration
- Include changes to the Shamir threshold in the evaluation of whether or not the file will change
- Present the changes to the Shamir threshold to the user for confirmation

**Example to reproduce the problem**
Use the following `.sops.yaml` to encrypt a file
```
creation_rules:
  - path_regex: <pattern>
    gcp_kms: <gcp_resource>
```
Then change `.sops.yaml` to 
```
creation_rules:
  - path_regex: <pattern>
    shamir_threshold: 2
    key_groups:
      - gcp_kms:
          - resource_id: <gcp_resource>
        age:
          - <age key 1>
      - age:
          - <age key 2>
          - <age key 3>
      - age:
          - <age key 4>
```

After running `sops updatekeys <filename>`, the resulting encrypted file has a metadata section starting with:
```
sops:
    shamir_threshold: 3
    key_groups:
        - gcp_kms:
           ...
```
I.e `shamir_threshold` in `.sops.yaml` was not respected, and the number of groups was used instead. 

**User experience after change**
Message when running `sops updatekeys <filename>` after changing `.sops.yaml` from no groups to 3 groups, with `shamir_threshold` configured as 2
```
The following changes will be made to the file's groups:
+++ shamir_threshold: 2
Group 1
    <gcp_resource>
+++ <age key 1>
Group 2
+++ <age key 2>
+++ <age key 3>
Group 3
+++ <age key 4>
Is this okay? (y/n):
```
After confirmation the the resulting encrypted file has a metadata section starting with:
```
sops:
    shamir_threshold: 2
    key_groups:
        - gcp_kms:
           ...
```

Message when changing `shamir_threshold` from 2 to 3 (equal to removing `shamir_threshold` from configuration)
```
The following changes will be made to the file's groups:
+++ shamir_threshold: 3
--- shamir_threshold: 2
Group 1
    <gcp_resource>
    <age key 1>
Group 2
    <age key 2>
    <age key 3>
Group 3
    <age key 4>
Is this okay? (y/n):
```
After confirmation the the resulting encrypted file has a metadata section starting with:
```
sops:
    shamir_threshold: 3
    key_groups:
        - gcp_kms:
           ...
```