### PR TITLE
feat: follow best practices with regards to naming .env files

### DIFF
--- a/cmd/sops/formats/formats.go
+++ b/cmd/sops/formats/formats.go
@@ -1,6 +1,9 @@
 package formats
 
-import "strings"
+import (
+	"path/filepath"
+	"strings"
+)
 
 // Format is an enum type
 type Format int
@@ -43,7 +46,7 @@ func IsJSONFile(path string) bool {
 
 // IsEnvFile returns true if a given file path corresponds to a .env file
 func IsEnvFile(path string) bool {
-	return strings.HasSuffix(path, ".env")
+	return strings.HasSuffix(path, ".env") || strings.HasPrefix(filepath.Base(path), ".env")
 }
 
 // IsIniFile returns true if a given file path corresponds to a INI file

--- a/cmd/sops/formats/formats_test.go
+++ b/cmd/sops/formats/formats_test.go
@@ -17,6 +17,7 @@ func TestFormatFromString(t *testing.T) {
 func TestFormatForPath(t *testing.T) {
 	assert.Equal(t, Binary, FormatForPath("/path/to/foobar"))
 	assert.Equal(t, Dotenv, FormatForPath("/path/to/foobar.env"))
+	assert.Equal(t, Dotenv, FormatForPath("/path/to/.env.foobar"))
 	assert.Equal(t, Ini, FormatForPath("/path/to/foobar.ini"))
 	assert.Equal(t, Json, FormatForPath("/path/to/foobar.json"))
 	assert.Equal(t, Yaml, FormatForPath("/path/to/foobar.yml"))
@@ -27,6 +28,7 @@ func TestFormatForPathOrString(t *testing.T) {
 	assert.Equal(t, Binary, FormatForPathOrString("/path/to/foobar", ""))
 	assert.Equal(t, Dotenv, FormatForPathOrString("/path/to/foobar", "dotenv"))
 	assert.Equal(t, Dotenv, FormatForPathOrString("/path/to/foobar.env", ""))
+	assert.Equal(t, Dotenv, FormatForPathOrString("/path/to/.env.foobar", ""))
 	assert.Equal(t, Ini, FormatForPathOrString("/path/to/foobar", "ini"))
 	assert.Equal(t, Ini, FormatForPathOrString("/path/to/foobar.ini", ""))
 	assert.Equal(t, Json, FormatForPathOrString("/path/to/foobar", "json"))


### PR DESCRIPTION
Many libraries and dev tools use .env files.  Typically different files are used for different environments like dev, staging, and production.  Typically, these are named .env.production with the designation happening _**after**_ the .env.

This change allows sops to recognize dotenv files named with .env at the beginning of the filename in addition to the suffix (current functionality)

