### PR TITLE
pgp: don't shorten key fingerprints

### DIFF
--- a/pgp/keysource.go
+++ b/pgp/keysource.go
@@ -321,8 +321,6 @@ func (key *MasterKey) encryptWithOpenPGP(dataKey []byte) error {
 // PGP key that belongs to Fingerprint. It sets EncryptedDataKey, or returns
 // an error.
 func (key *MasterKey) encryptWithGnuPG(dataKey []byte) error {
-	fingerprint := shortenFingerprint(key.Fingerprint)
-
 	args := []string{
 		"--no-default-recipient",
 		"--yes",
@@ -331,7 +329,7 @@ func (key *MasterKey) encryptWithGnuPG(dataKey []byte) error {
 		"-r",
 		key.Fingerprint,
 		"--trusted-key",
-		fingerprint,
+		key.Fingerprint,
 		"--no-encrypt-to",
 	}
 	stdout, stderr, err := gpgExec(key.gnuPGHomeDir, args, bytes.NewReader(dataKey))
@@ -628,14 +626,4 @@ func gnuPGHome(customPath string) string {
 		return filepath.Join(usr.HomeDir, ".gnupg")
 	}
 	return dir
-}
-
-// shortenFingerprint returns the short ID of the given fingerprint.
-// This is mostly used for compatibility reasons, as older versions of GnuPG
-// do not always like long IDs.
-func shortenFingerprint(fingerprint string) string {
-	if offset := len(fingerprint) - 16; offset > 0 {
-		fingerprint = fingerprint[offset:]
-	}
-	return fingerprint
 }

--- a/pgp/keysource_test.go
+++ b/pgp/keysource_test.go
@@ -338,8 +338,6 @@ func TestMasterKey_Decrypt(t *testing.T) {
 	})
 	assert.NoError(t, gnuPGHome.ImportFile(mockPrivateKey))
 
-	fingerprint := shortenFingerprint(mockFingerprint)
-
 	data := []byte("this data is absolutely top secret")
 	stdout, stderr, err := gpgExec(gnuPGHome.String(), []string{
 		"--no-default-recipient",
@@ -347,9 +345,9 @@ func TestMasterKey_Decrypt(t *testing.T) {
 		"--encrypt",
 		"-a",
 		"-r",
-		fingerprint,
+		mockFingerprint,
 		"--trusted-key",
-		fingerprint,
+		mockFingerprint,
 		"--no-encrypt-to",
 	}, bytes.NewReader(data))
 	assert.Nil(t, err)
@@ -421,8 +419,6 @@ func TestMasterKey_decryptWithOpenPGP(t *testing.T) {
 		})
 		assert.NoError(t, gnuPGHome.ImportFile(mockPrivateKey))
 
-		fingerprint := shortenFingerprint(mockFingerprint)
-
 		data := []byte("this data is absolutely top secret")
 		stdout, stderr, err := gpgExec(gnuPGHome.String(), []string{
 			"--no-default-recipient",
@@ -430,9 +426,9 @@ func TestMasterKey_decryptWithOpenPGP(t *testing.T) {
 			"--encrypt",
 			"-a",
 			"-r",
-			fingerprint,
+			mockFingerprint,
 			"--trusted-key",
-			fingerprint,
+			mockFingerprint,
 			"--no-encrypt-to",
 		}, bytes.NewReader(data))
 		assert.Nil(t, err)
@@ -470,8 +466,6 @@ func TestMasterKey_decryptWithGnuPG(t *testing.T) {
 		})
 		assert.NoError(t, gnuPGHome.ImportFile(mockPrivateKey))
 
-		fingerprint := shortenFingerprint(mockFingerprint)
-
 		data := []byte("this data is absolutely top secret")
 		stdout, stderr, err := gpgExec(gnuPGHome.String(), []string{
 			"--no-default-recipient",
@@ -479,9 +473,9 @@ func TestMasterKey_decryptWithGnuPG(t *testing.T) {
 			"--encrypt",
 			"-a",
 			"-r",
-			fingerprint,
+			mockFingerprint,
 			"--trusted-key",
-			fingerprint,
+			mockFingerprint,
 			"--no-encrypt-to",
 		}, bytes.NewReader(data))
 		assert.Nil(t, err)
@@ -694,13 +688,6 @@ func Test_gnuPGHome(t *testing.T) {
 
 	customP := "/home/dir/overwrite"
 	assert.Equal(t, customP, gnuPGHome(customP))
-}
-
-func Test_shortenFingerprint(t *testing.T) {
-	shortId := shortenFingerprint(mockFingerprint)
-	assert.Equal(t, "9732075EA221A7EA", shortId)
-
-	assert.Equal(t, shortId, shortenFingerprint(shortId))
 }
 
 // TODO(hidde): previous tests kept around for now.


### PR DESCRIPTION
As @mammothbane already identified in #1365, the pgp module is stripping the trailing exclamation mark from fingerprints that pgp uses to identify specific subkeys.
Because the shortened fingerprint refers to the whole key instead of just the subkey, I can't decrypt any secrets I encrypt for that subkey.

According to the doc comment, this was meant for compatibility with older GPG versions. I don't know which incompatibilities @hiddeco was referring to here, or if they are still relevant.

https://github.com/getsops/sops/blob/1c46d2492192cc55bc33baf6b9b78889fe3e795a/pgp/keysource.go#L633-L635



Fixes #1365