### PR TITLE
Fix the URL used for determining the latest SOPS version

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -101,7 +101,7 @@ func RetrieveLatestVersionFromUpstream() (string, error) {
 //
 // Unlike RetrieveLatestVersionFromUpstream, it returns the tag (e.g. "v3.7.3").
 func RetrieveLatestReleaseVersion() (tag, url string, err error) {
-	const repository = "mozilla/sops"
+	const repository = "getsops/sops"
 	return newReleaseFetcher().LatestRelease(repository)
 }
 


### PR DESCRIPTION
Right now the code does a HEAD to https://github.com/mozilla/sops/releases/latest and then follows the 301 redirect and does a HEAD to https://github.com/getsops/sops/releases/latest to obtain the version from the 302 redirect that returns.

Since the repo has been renamed, I think we can skip the mozilla/sops step and directly ask getsops/sops.

(The original URL was added in #1261, I'm not sure why we used mozilla/sops there instead of getsops/sops.)