### PR TITLE
tests: ignore env var SOPS_AGE_KEY_FILE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ checkmd: $(MD_FILES)
 .PHONY: test
 test: vendor
 	gpg --import pgp/sops_functional_tests_key.asc 2>&1 1>/dev/null || exit 0
-	LANG=en_US.UTF-8 $(GO) test $(GO_TEST_FLAGS) ./...
+	unset SOPS_AGE_KEY_FILE; LANG=en_US.UTF-8 $(GO) test $(GO_TEST_FLAGS) ./...
 
 .PHONY: showcoverage
 showcoverage: test


### PR DESCRIPTION
Why:

* setting the variable SOPS_AGE_KEY_FILE will make tests fail

I also looked at other env variables, but only `SOPS_GPG_EXEC` would cause an issue. I guess keeping this variable could be useful to run tests in a non-standard environment, so I did not include it in the variables to unset.

Fixes https://github.com/getsops/sops/issues/1410