### PR TITLE
Do not encrypt if a key group is empty, or there are no key groups

### DIFF
--- a/functional-tests/.sops.yaml
+++ b/functional-tests/.sops.yaml
@@ -11,6 +11,12 @@ creation_rules:
         - FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
       - pgp:
         - B611A2F9F11D0FF82568805119F9B5DAEA91FF86
+    - path_regex: test_no_keygroups.yaml
+    - path_regex: test_zero_keygroups.yaml
+      key_groups: []
+    - path_regex: test_empty_keygroup.yaml
+      key_groups:
+        - {}
     - pgp: FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
 destination_rules:
     - s3_bucket: "sops-publish-functional-tests"

--- a/functional-tests/src/lib.rs
+++ b/functional-tests/src/lib.rs
@@ -950,6 +950,66 @@ b: ba"#
     }
 
     #[test]
+    fn test_no_keygroups() {
+        // The .sops.yaml file ensures this file is encrypted by zero keygroups
+        let file_path = prepare_temp_file("test_no_keygroups.yaml", "a: secret".as_bytes());
+        let output = Command::new(SOPS_BINARY_PATH)
+            .arg("encrypt")
+            .arg("-i")
+            .arg(file_path.clone())
+            .output()
+            .expect("Error running sops");
+        assert!(
+            !output.status.success(),
+            "SOPS succeeded encrypting a file without a key group"
+        );
+        assert_eq!(
+            std::str::from_utf8(&output.stderr).unwrap(),
+            "Could not generate data key: [empty key group provided]\n"
+        );
+    }
+
+    #[test]
+    fn test_zero_keygroups() {
+        // The .sops.yaml file ensures this file is encrypted by zero keygroups
+        let file_path = prepare_temp_file("test_zero_keygroups.yaml", "a: secret".as_bytes());
+        let output = Command::new(SOPS_BINARY_PATH)
+            .arg("encrypt")
+            .arg("-i")
+            .arg(file_path.clone())
+            .output()
+            .expect("Error running sops");
+        assert!(
+            !output.status.success(),
+            "SOPS succeeded encrypting a file without a key group"
+        );
+        assert_eq!(
+            std::str::from_utf8(&output.stderr).unwrap(),
+            "Could not generate data key: [empty key group provided]\n"
+        );
+    }
+
+    #[test]
+    fn test_empty_keygroup() {
+        // The .sops.yaml file ensures this file is encrypted by zero keygroups
+        let file_path = prepare_temp_file("test_empty_keygroup.yaml", "a: secret".as_bytes());
+        let output = Command::new(SOPS_BINARY_PATH)
+            .arg("encrypt")
+            .arg("-i")
+            .arg(file_path.clone())
+            .output()
+            .expect("Error running sops");
+        assert!(
+            !output.status.success(),
+            "SOPS succeeded encrypting a file without a key group"
+        );
+        assert_eq!(
+            std::str::from_utf8(&output.stderr).unwrap(),
+            "Could not generate data key: [empty key group provided]\n"
+        );
+    }
+
+    #[test]
     fn extract_string() {
         let file_path = prepare_temp_file(
             "test_extract_string.yaml",

--- a/sops.go
+++ b/sops.go
@@ -700,6 +700,11 @@ func (m *Metadata) UpdateMasterKeysWithKeyServices(dataKey []byte, svcs []keyser
 			fmt.Errorf("no key services provided, cannot update master keys"),
 		}
 	}
+	if len(m.KeyGroups) == 0 {
+		return []error{
+			fmt.Errorf("no key groups provided"),
+		}
+	}
 	var parts [][]byte
 	if len(m.KeyGroups) == 1 {
 		// If there's only one key group, we can't do Shamir. All keys
@@ -726,6 +731,11 @@ func (m *Metadata) UpdateMasterKeysWithKeyServices(dataKey []byte, svcs []keyser
 	}
 	for i, group := range m.KeyGroups {
 		part := parts[i]
+		if len(group) == 0 {
+			return []error{
+				fmt.Errorf("empty key group provided"),
+			}
+		}
 		for _, key := range group {
 			svcKey := keyservice.KeyFromMasterKey(key)
 			var keyErrs []error


### PR DESCRIPTION
Fixes #479.