### PR TITLE
GitHub Actions linter for Rust formatting

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,0 +1,27 @@
+name: Linters
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    # Only run when linted files change
+    paths:
+      - 'functional-tests/**/*.rs'
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint Rust source files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Run Formatting Check
+        run: cargo fmt --check
+        working-directory: ./functional-tests

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Install rustup
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y --default-toolchain 1.70.0
+
       - name: Run Formatting Check
         run: cargo fmt --check
         working-directory: ./functional-tests

--- a/functional-tests/src/lib.rs
+++ b/functional-tests/src/lib.rs
@@ -552,8 +552,10 @@ b: ba"#
     #[test]
     fn unset_json_file() {
         // Test removal of tree branch
-        let file_path =
-            prepare_temp_file("test_unset.json", r#"{"a": 2, "b": "ba", "c": [1,2]}"#.as_bytes());
+        let file_path = prepare_temp_file(
+            "test_unset.json",
+            r#"{"a": 2, "b": "ba", "c": [1,2]}"#.as_bytes(),
+        );
         assert!(
             Command::new(SOPS_BINARY_PATH)
                 .arg("encrypt")
@@ -661,8 +663,10 @@ b: ba"#
     #[test]
     fn unset_yaml_file() {
         // Test removal of tree branch
-        let file_path =
-            prepare_temp_file("test_unset.yaml", r#"{"a": 2, "b": "ba", "c": [1,2]}"#.as_bytes());
+        let file_path = prepare_temp_file(
+            "test_unset.yaml",
+            r#"{"a": 2, "b": "ba", "c": [1,2]}"#.as_bytes(),
+        );
         assert!(
             Command::new(SOPS_BINARY_PATH)
                 .arg("encrypt")


### PR DESCRIPTION
This PR takes the changes from https://github.com/getsops/sops/pull/1403 and applies them in a dedicated CI workflow.

Fixes https://github.com/getsops/sops/pull/1390