### PR TITLE
updatekeys subcommand: actually use option `--shamir-secret-sharing-threshold`

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -644,7 +644,7 @@ func main() {
 				for _, path := range c.Args() {
 					err := updatekeys.UpdateKeys(updatekeys.Opts{
 						InputPath:   path,
-						GroupQuorum: c.Int("shamir-secret-sharing-quorum"),
+						GroupQuorum: c.Int("shamir-secret-sharing-threshold"),
 						KeyServices: keyservices(c),
 						Interactive: !c.Bool("yes"),
 						ConfigPath:  configPath,


### PR DESCRIPTION
The option was renamed while the `updatekeys` subcommand was developed, and the name was not updated in the `updatekeys` PR. See the following for more information: https://github.com/getsops/sops/pull/1509#discussion_r1623288498