### PR TITLE
updatekeys subcommand: show changes in shamir_threshold

### DIFF
--- a/cmd/sops/common/common.go
+++ b/cmd/sops/common/common.go
@@ -447,3 +447,17 @@ func PrettyPrintDiffs(diffs []Diff) {
 		}
 	}
 }
+
+// PrettyPrintShamirDiff prints changes in shamir_threshold to stdout
+func PrettyPrintShamirDiff(oldValue, newValue int) {
+	if oldValue > 0 && oldValue == newValue {
+		fmt.Printf("shamir_threshold: %d\n", newValue)
+	} else {
+		if newValue > 0 {
+			color.New(color.FgGreen).Printf("+++ shamir_threshold: %d\n", newValue)
+		}
+		if oldValue > 0 {
+			color.New(color.FgRed).Printf("--- shamir_threshold: %d\n", oldValue)
+		}
+	}
+}

--- a/cmd/sops/subcommand/updatekeys/updatekeys.go
+++ b/cmd/sops/subcommand/updatekeys/updatekeys.go
@@ -66,11 +66,22 @@ func updateFile(opts Opts) error {
 			keysWillChange = true
 		}
 	}
-	if !keysWillChange {
+
+	// TODO: use conf.ShamirThreshold instead of tree.Metadata.ShamirThreshold in the next line?
+	//       Or make this configurable?
+	var shamirThreshold = tree.Metadata.ShamirThreshold
+	if opts.GroupQuorum != 0 {
+		shamirThreshold = opts.GroupQuorum
+	}
+	shamirThreshold = min(shamirThreshold, len(conf.KeyGroups))
+	var shamirThresholdWillChange = tree.Metadata.ShamirThreshold != shamirThreshold
+
+	if !keysWillChange && !shamirThresholdWillChange {
 		log.Printf("File %s already up to date", opts.InputPath)
 		return nil
 	}
 	fmt.Printf("The following changes will be made to the file's groups:\n")
+	common.PrettyPrintShamirDiff(tree.Metadata.ShamirThreshold, shamirThreshold)
 	common.PrettyPrintDiffs(diffs)
 
 	if opts.Interactive {
@@ -92,10 +103,7 @@ func updateFile(opts Opts) error {
 		return common.NewExitError(err, codes.CouldNotRetrieveKey)
 	}
 	tree.Metadata.KeyGroups = conf.KeyGroups
-	if opts.GroupQuorum != 0 {
-		tree.Metadata.ShamirThreshold = opts.GroupQuorum
-	}
-	tree.Metadata.ShamirThreshold = min(tree.Metadata.ShamirThreshold, len(tree.Metadata.KeyGroups))
+	tree.Metadata.ShamirThreshold = shamirThreshold
 	errs := tree.Metadata.UpdateMasterKeysWithKeyServices(key, opts.KeyServices)
 	if len(errs) > 0 {
 		return fmt.Errorf("error updating one or more master keys: %s", errs)


### PR DESCRIPTION
Inspired by #1509. Also fixes that changes in the Shamir threshold are detected (when the command line flag is used, see #1608).

This does not change the behavior which Shamir threshold is actually used (see the `TODO` comment), that raised the original change in #1509. I'm currently thinking that it should be the user's choice and that should be added as a feature, not a bugfix.