### PR TITLE
github actions: set rust version globally

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -85,11 +85,17 @@ jobs:
       VAULT_TOKEN: "root"
       VAULT_ADDR: "http://127.0.0.1:8200"
     steps:
-      - name: Install rustup
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y --default-toolchain 1.70.0
-
       - name: Check out code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      # Rustup will detect toolchain version and profile from rust-toolchain.toml
+      # It will download and install the toolchain and components automatically
+      # and make them available for subsequent commands
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Show Rust version
+        run: cargo --version
 
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -7,8 +7,9 @@ on:
   pull_request:
     branches:
       - main
-    # Only run when linted files change
+    # Only run when Rust version or linted files change
     paths:
+      - 'rust-toolchain.toml'
       - 'functional-tests/**/*.rs'
 
 permissions:
@@ -22,8 +23,14 @@ jobs:
       - name: Check out code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: Install rustup
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y --default-toolchain 1.70.0
+      # Rustup will detect toolchain version and profile from rust-toolchain.toml
+      # It will download and install the toolchain and components automatically
+      # and make them available for subsequent commands
+      - name: Install Rust toolchain and additional components
+        run: rustup component add rustfmt
+
+      - name: Show Rust version
+        run: cargo --version
 
       - name: Run Formatting Check
         run: cargo fmt --check

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.70.0"
+profile = "minimal"


### PR DESCRIPTION
Following https://github.com/getsops/sops/pull/1604, we now have two different GH actions requiring a version of Rust.

Rustup allows setting the toolchain version in a file `rust-toolchain.toml`, allowing to set the Rust version once for all Rust commands.