### PR TITLE
Fix `--config` being ignored by `loadConfig`

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -2040,10 +2040,8 @@ func keyservices(c *cli.Context) (svcs []keyservice.KeyServiceClient) {
 }
 
 func loadStoresConfig(context *cli.Context, path string) (*config.StoresConfig, error) {
-	var configPath string
-	if context.String("config") != "" {
-		configPath = context.String("config")
-	} else {
+	configPath := context.GlobalString("config")
+	if configPath == "" {
 		// Ignore config not found errors returned from FindConfigFile since the config file is not mandatory
 		foundPath, err := config.FindConfigFile(".")
 		if err != nil {
@@ -2178,10 +2176,8 @@ func keyGroups(c *cli.Context, file string) ([]sops.KeyGroup, error) {
 // Since a config file is not required, this function does not error when one is not found, and instead returns a nil config pointer
 func loadConfig(c *cli.Context, file string, kmsEncryptionContext map[string]*string) (*config.Config, error) {
 	var err error
-	var configPath string
-	if c.String("config") != "" {
-		configPath = c.String("config")
-	} else {
+	configPath := c.GlobalString("config")
+	if configPath == "" {
 		// Ignore config not found errors returned from FindConfigFile since the config file is not mandatory
 		configPath, err = config.FindConfigFile(".")
 		if err != nil {


### PR DESCRIPTION
Use `GlobalString` in `loadConfig` since `--config` is not a sub-command flag.

This fixes `--config` being ignored and the CLI erroring out in a maddening way:

```
% sops --config config/sops.yaml encrypt --input-type json --output-type yaml /dev/stdin < data/test.json | head -n 3
config file not found, or has no creation rules, and no keys provided through command line options
% tree
./
├── config/
│   └── sops.yaml
└── data/
    └── test.json

3 directories, 2 files
% cat config/sops.yaml
creation_rules:
- path_regex: .*
  pgp: ADB6276965590A096004F6D1E114CBAE8FA29165
% cat data/test.json
{
    "key": 42
}
%
```

Maybe there is more to this fix, and I am happy to hear about it.

---

FWIW and future reference, here is how I got a debug build on Nix to debug this issue with delve:

```
$ cat ~/snippets/sops-debug-build.nix
sops.overrideAttrs(final: prev: {
  ldflags = [ "-X github.com/getsops/sops/v3/version.Version=${prev.version}" ];
  GOFLAGS = prev.GOFLAGS ++ [ "'-gcflags=all=-N -l'" ];
  dontStrip = true;
})
$ nix-store --realise $(nix-instantiate ~/snippets/sops-debug-build.nix)
```