### PR TITLE
Do not ignore errors when trying to parse a config file

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -171,7 +171,10 @@ func main() {
 				fileName := c.Args()[0]
 				command := c.Args()[1]
 
-				inputStore := inputStore(c, fileName)
+				inputStore, err := inputStore(c, fileName)
+				if err != nil {
+					return toExitError(err)
+				}
 
 				svcs := keyservices(c)
 
@@ -272,8 +275,14 @@ func main() {
 				fileName := c.Args()[0]
 				command := c.Args()[1]
 
-				inputStore := inputStore(c, fileName)
-				outputStore := outputStore(c, fileName)
+				inputStore, err := inputStore(c, fileName)
+				if err != nil {
+					return toExitError(err)
+				}
+				outputStore, err := outputStore(c, fileName)
+				if err != nil {
+					return toExitError(err)
+				}
 
 				svcs := keyservices(c)
 
@@ -365,13 +374,17 @@ func main() {
 						return toExitError(err)
 					}
 					if !info.IsDir() {
+						inputStore, err := inputStore(c, subPath)
+						if err != nil {
+							return toExitError(err)
+						}
 						err = publishcmd.Run(publishcmd.Opts{
 							ConfigPath:      configPath,
 							InputPath:       subPath,
 							Cipher:          aes.NewCipher(),
 							KeyServices:     keyservices(c),
 							DecryptionOrder: order,
-							InputStore:      inputStore(c, subPath),
+							InputStore:      inputStore,
 							Interactive:     !c.Bool("yes"),
 							OmitExtensions:  c.Bool("omit-extensions"),
 							Recursive:       c.Bool("recursive"),
@@ -440,7 +453,10 @@ func main() {
 				}
 
 				fileName := c.Args()[0]
-				inputStore := inputStore(c, fileName)
+				inputStore, err := inputStore(c, fileName)
+				if err != nil {
+					return toExitError(err)
+				}
 				opts := filestatuscmd.Opts{
 					InputStore: inputStore,
 					InputPath:  fileName,
@@ -560,11 +576,19 @@ func main() {
 								group = append(group, key)
 							}
 						}
+						inputStore, err := inputStore(c, c.String("file"))
+						if err != nil {
+							return toExitError(err)
+						}
+						outputStore, err := outputStore(c, c.String("file"))
+						if err != nil {
+							return toExitError(err)
+						}
 						return groups.Add(groups.AddOpts{
 							InputPath:      c.String("file"),
 							InPlace:        c.Bool("in-place"),
-							InputStore:     inputStore(c, c.String("file")),
-							OutputStore:    outputStore(c, c.String("file")),
+							InputStore:     inputStore,
+							OutputStore:    outputStore,
 							Group:          group,
 							GroupThreshold: c.Int("shamir-secret-sharing-threshold"),
 							KeyServices:    keyservices(c),
@@ -599,11 +623,19 @@ func main() {
 							return fmt.Errorf("failed to parse [index] argument: %s", err)
 						}
 
+						inputStore, err := inputStore(c, c.String("file"))
+						if err != nil {
+							return toExitError(err)
+						}
+						outputStore, err := outputStore(c, c.String("file"))
+						if err != nil {
+							return toExitError(err)
+						}
 						return groups.Delete(groups.DeleteOpts{
 							InputPath:      c.String("file"),
 							InPlace:        c.Bool("in-place"),
-							InputStore:     inputStore(c, c.String("file")),
-							OutputStore:    outputStore(c, c.String("file")),
+							InputStore:     inputStore,
+							OutputStore:    outputStore,
 							Group:          uint(group),
 							GroupThreshold: c.Int("shamir-secret-sharing-threshold"),
 							KeyServices:    keyservices(c),
@@ -735,8 +767,14 @@ func main() {
 					fileNameOverride = fileName
 				}
 
-				inputStore := inputStore(c, fileNameOverride)
-				outputStore := outputStore(c, fileNameOverride)
+				inputStore, err := inputStore(c, fileNameOverride)
+				if err != nil {
+					return toExitError(err)
+				}
+				outputStore, err := outputStore(c, fileNameOverride)
+				if err != nil {
+					return toExitError(err)
+				}
 				svcs := keyservices(c)
 
 				order, err := decryptionOrder(c.String("decryption-order"))
@@ -899,8 +937,14 @@ func main() {
 					fileNameOverride = fileName
 				}
 
-				inputStore := inputStore(c, fileNameOverride)
-				outputStore := outputStore(c, fileNameOverride)
+				inputStore, err := inputStore(c, fileNameOverride)
+				if err != nil {
+					return toExitError(err)
+				}
+				outputStore, err := outputStore(c, fileNameOverride)
+				if err != nil {
+					return toExitError(err)
+				}
 				svcs := keyservices(c)
 
 				encConfig, err := getEncryptConfig(c, fileNameOverride)
@@ -1058,8 +1102,14 @@ func main() {
 					fileNameOverride = fileName
 				}
 
-				inputStore := inputStore(c, fileNameOverride)
-				outputStore := outputStore(c, fileNameOverride)
+				inputStore, err := inputStore(c, fileNameOverride)
+				if err != nil {
+					return toExitError(err)
+				}
+				outputStore, err := outputStore(c, fileNameOverride)
+				if err != nil {
+					return toExitError(err)
+				}
 				svcs := keyservices(c)
 
 				order, err := decryptionOrder(c.String("decryption-order"))
@@ -1203,8 +1253,14 @@ func main() {
 					return toExitError(err)
 				}
 
-				inputStore := inputStore(c, fileName)
-				outputStore := outputStore(c, fileName)
+				inputStore, err := inputStore(c, fileName)
+				if err != nil {
+					return toExitError(err)
+				}
+				outputStore, err := outputStore(c, fileName)
+				if err != nil {
+					return toExitError(err)
+				}
 				svcs := keyservices(c)
 
 				order, err := decryptionOrder(c.String("decryption-order"))
@@ -1298,8 +1354,14 @@ func main() {
 					return toExitError(err)
 				}
 
-				inputStore := inputStore(c, fileName)
-				outputStore := outputStore(c, fileName)
+				inputStore, err := inputStore(c, fileName)
+				if err != nil {
+					return toExitError(err)
+				}
+				outputStore, err := outputStore(c, fileName)
+				if err != nil {
+					return toExitError(err)
+				}
 				svcs := keyservices(c)
 
 				path, err := parseTreePath(c.Args()[1])
@@ -1389,8 +1451,14 @@ func main() {
 					return toExitError(err)
 				}
 
-				inputStore := inputStore(c, fileName)
-				outputStore := outputStore(c, fileName)
+				inputStore, err := inputStore(c, fileName)
+				if err != nil {
+					return toExitError(err)
+				}
+				outputStore, err := outputStore(c, fileName)
+				if err != nil {
+					return toExitError(err)
+				}
 				svcs := keyservices(c)
 
 				path, err := parseTreePath(c.Args()[1])
@@ -1687,8 +1755,14 @@ func main() {
 			}
 		}
 
-		inputStore := inputStore(c, fileNameOverride)
-		outputStore := outputStore(c, fileNameOverride)
+		inputStore, err := inputStore(c, fileNameOverride)
+		if err != nil {
+			return toExitError(err)
+		}
+		outputStore, err := outputStore(c, fileNameOverride)
+		if err != nil {
+			return toExitError(err)
+		}
 		svcs := keyservices(c)
 
 		order, err := decryptionOrder(c.String("decryption-order"))
@@ -2049,13 +2123,19 @@ func loadStoresConfig(context *cli.Context, path string) (*config.StoresConfig, 
 	return config.LoadStoresConfig(configPath)
 }
 
-func inputStore(context *cli.Context, path string) common.Store {
-	storesConf, _ := loadStoresConfig(context, path)
-	return common.DefaultStoreForPathOrFormat(storesConf, path, context.String("input-type"))
+func inputStore(context *cli.Context, path string) (common.Store, error) {
+	storesConf, err := loadStoresConfig(context, path)
+	if err != nil {
+		return nil, err
+	}
+	return common.DefaultStoreForPathOrFormat(storesConf, path, context.String("input-type")), nil
 }
 
-func outputStore(context *cli.Context, path string) common.Store {
-	storesConf, _ := loadStoresConfig(context, path)
+func outputStore(context *cli.Context, path string) (common.Store, error) {
+	storesConf, err := loadStoresConfig(context, path)
+	if err != nil {
+		return nil, err
+	}
 	if context.IsSet("indent") {
 		indent := context.Int("indent")
 		storesConf.YAML.Indent = indent
@@ -2063,7 +2143,7 @@ func outputStore(context *cli.Context, path string) common.Store {
 		storesConf.JSONBinary.Indent = indent
 	}
 
-	return common.DefaultStoreForPathOrFormat(storesConf, path, context.String("output-type"))
+	return common.DefaultStoreForPathOrFormat(storesConf, path, context.String("output-type")), nil
 }
 
 func parseTreePath(arg string) ([]interface{}, error) {


### PR DESCRIPTION
Found while playing around with #1613: `sops --config /does/not/exist encrypt foo.sops.yml` resulted in a panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1127533]

goroutine 1 [running]:
github.com/getsops/sops/v3/cmd/sops/common.newYamlStore(0x0)
	/path/to/sops/cmd/sops/common/common.go:58 +0x13
github.com/getsops/sops/v3/cmd/sops/common.StoreForFormat(...)
	/path/to/sops/cmd/sops/common/common.go:164
github.com/getsops/sops/v3/cmd/sops/common.DefaultStoreForPathOrFormat(0x0, {0xc0001800a0, 0x46}, {0x0?, 0x14974f9?})
	/path/to/sops/cmd/sops/common/common.go:179 +0x9d
main.inputStore(0xc00018d4a0, {0xc0001800a0, 0x46})
	/path/to/sops/cmd/sops/main.go:2059 +0x65
main.main.func10(0xc00018d4a0)
	/path/to/sops/cmd/sops/main.go:902 +0x1cc
github.com/urfave/cli.HandleAction({0x1226900?, 0x1503850?}, 0x7?)
	/path/to/sops/vendor/github.com/urfave/cli/app.go:524 +0x50
github.com/urfave/cli.Command.Run({{0x14887a3, 0x7}, {0x0, 0x0}, {0x0, 0x0, 0x0}, {0x14c7d82, 0x30}, {0x0, ...}, ...}, ...)
	/path/to/sops/vendor/github.com/urfave/cli/command.go:175 +0x67c
github.com/urfave/cli.(*App).Run(0xc0004e2540, {0xc000138000, 0x5, 0x5})
	/path/to/sops/vendor/github.com/urfave/cli/app.go:277 +0xb3b
main.main()
	/path/to/sops/cmd/sops/main.go:1839 +0x6be5
```