### PR TITLE
Build release with Go 1.22.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v4.0.1
         with:
-          go-version: 1.22.x
+          go-version-file: go.mod
           cache: false
 
       - name: Setup Syft

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v4.0.1
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
           cache: false
 
       - name: Setup Syft


### PR DESCRIPTION
The Go version for CI is upgraded in #1531, but for the release process we're still using 1.21.x.

Ref: #1572