### PR TITLE
Add 'check' task to CI that makes sure everything is green

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -122,3 +122,22 @@ jobs:
       - name: Run tests
         run: cargo test
         working-directory: ./functional-tests
+
+  # The 'check' job should depend on all other jobs so it's possible to configure branch protection only for 'check'
+  # instead of having to explicitly list all individual jobs that need to pass.
+  check:
+    if: always()
+
+    needs:
+      - build
+      - test
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          allowed-failures: docs, linters
+          allowed-skips: non-voting-flaky-job
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
This allows to simply the branch protection steps, which in turn makes it easier to upgrade CI without having to adjust the branch protection conditions every time.

Ref: https://github.com/getsops/sops/pull/1531#pullrequestreview-2304547983
Ref: https://github.com/re-actors/alls-green?tab=readme-ov-file#alls-green