### PR TITLE
GHA: fix checkout action version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.0.0
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Install rstcheck and markdownlint
         run: |


### PR DESCRIPTION
Because it has the wrong version there, Dependabot isn't updating the comment.

If you grep for `actions/checkout` in `.github`, you'll see that all other instances have the same image hash, and all of them have `v4.1.7` in their comment.