### PR TITLE
fix(azkv): handle whitespace in Azure Key Vault URLs

### DIFF
--- a/azkv/keysource.go
+++ b/azkv/keysource.go
@@ -76,6 +76,7 @@ func NewMasterKey(vaultURL string, keyName string, keyVersion string) *MasterKey
 // NewMasterKeyFromURL takes an Azure Key Vault key URL, and returns a new
 // MasterKey. The URL format is {vaultUrl}/keys/{keyName}/{keyVersion}.
 func NewMasterKeyFromURL(url string) (*MasterKey, error) {
+	url = strings.TrimSpace(url)
 	re := regexp.MustCompile("^(https://[^/]+)/keys/([^/]+)/([^/]+)$")
 	parts := re.FindStringSubmatch(url)
 	if parts == nil || len(parts) < 3 {

--- a/azkv/keysource_test.go
+++ b/azkv/keysource_test.go
@@ -89,6 +89,23 @@ func TestMasterKeysFromURLs(t *testing.T) {
 			},
 		},
 		{
+			name:           "multiple URLs with leading and trailing spaces",
+			urls:           " https://test.vault.azure.net/keys/test-key/a2a690a4fcc04166b739da342a912c90 ,  https://test2.vault.azure.net/keys/another-test-key/cf0021e8b743453bae758e7fbf71b60e  ",
+			expectKeyCount: 2,
+			expectKeys: []MasterKey{
+				{
+					VaultURL: "https://test.vault.azure.net",
+					Name:     "test-key",
+					Version:  "a2a690a4fcc04166b739da342a912c90",
+				},
+				{
+					VaultURL: "https://test2.vault.azure.net",
+					Name:     "another-test-key",
+					Version:  "cf0021e8b743453bae758e7fbf71b60e",
+				},
+			},
+		},
+		{
 			name:      "multiple URLs, one malformed",
 			urls:      "https://test.vault.azure.net/keys/test-key/a2a690a4fcc04166b739da342a912c90,https://test.vault.azure.net/no-keys-here/test-key/a2a690a4fcc04166b739da342a912c90",
 			expectErr: true,


### PR DESCRIPTION
### Problem:

The Azure Key Vault key parser would fail when URLs contained leading or trailing whitespace, which commonly occurs when using YAML Block Scalar syntax.

```yaml
creation_rules:
  - azure_keyvault: >-
      https://test.vault.azure.net/keys/test-key/a2a690a4fcc04166b739da342a912c90,
      https://test2.vault.azure.net/keys/another-test-key/cf0021e8b743453bae758e7fbf71b60e
```

This resulted in the error:

```bash
could not parse " https://test2.vault.azure.net/keys/another-test-key/cf0021e8b743453bae758e7fbf71b60e" into a valid Azure Key Vault MasterKey
```

### Fix:

- Added `strings.TrimSpace()` to clean the URL before parsing in `NewMasterKeyFromURL()`
- Added test case to verify handling of URLs with leading/trailing spaces