### PR TITLE
Add a clue for editors under "sops edit"

### DIFF
--- a/cmd/sops/edit.go
+++ b/cmd/sops/edit.go
@@ -265,6 +265,7 @@ func runEditor(path string) error {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.Env = append(cmd.Environ(), "SOPS_IS_EDITING=true")
 	return cmd.Run()
 }
 


### PR DESCRIPTION
Sometimes there are things we'd prefer our editors do differently when editing files with secrets in them: different configuration, disable certain plugins, etc.  This change sets a clue in the launched editor's environment that can be used to easily and trivially determine if the editor was launched by `sops edit`.