### PR TITLE
Allow to encrypt and decrypt from stdin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -382,7 +382,7 @@ Encrypting and decrypting from other programs
 When using ``sops`` in scripts or from other programs, there are often situations where you do not want to write
 encrypted or decrypted data to disk. The best way to avoid this is to pass data to SOPS via stdin, and to let
 SOPS write data to stdout. By default, the encrypt and decrypt operations write data to stdout already. To pass
-data via stdin, you need to not provide an input filename. For encrpytion, you also must provide the
+data via stdin, you need to not provide an input filename. For encryption, you also must provide the
 ``--filename-override`` option with the file's filename. The filename will be used to determine the input and output
 types, and to select the correct creation rule.
 

--- a/README.rst
+++ b/README.rst
@@ -386,21 +386,26 @@ data via stdin, you need to not provide an input filename. For encryption, you a
 ``--filename-override`` option with the file's filename. The filename will be used to determine the input and output
 types, and to select the correct creation rule.
 
-To decrypt data, you can simply do:
+The simplest way to decrypt data from stdin is as follows:
+
+.. code:: sh
+
+	$ cat encrypted-data | sops decrypt > decrypted-data
+
+By default, ``sops`` determines the input and output format from the provided filename. Since in this case,
+no filename is provided, ``sops`` will use the binary store which expects JSON input and outputs binary data
+on decryption. This is often not what you want.
+
+To avoid this, you can either provide a filename with ``--filename-override``, or explicitly control
+the input and output formats by passing ``--input-type`` and ``--output-type`` as appropriate:
 
 .. code:: sh
 
 	$ cat encrypted-data | sops decrypt --filename-override filename.yaml > decrypted-data
-
-To control the input and output format, pass ``--input-type`` and ``--output-type`` as appropriate. By default,
-``sops`` determines the input and output format from the provided filename, which is the empty string here, and
-thus will use the binary store which expects JSON input and outputs binary data on decryption.
-
-For example, to decrypt YAML data and obtain the decrypted result as YAML, use:
-
-.. code:: sh
-
 	$ cat encrypted-data | sops decrypt --input-type yaml --output-type yaml > decrypted-data
+
+In both cases, ``sops`` will assume that the data you provide is in YAML format, and will encode the decrypted
+data in YAML as well. The second form allows to use different formats for input and output.
 
 To encrypt, it is important to note that SOPS also uses the filename to look up the correct creation rule from
 ``.sops.yaml``. Therefore, you must provide the ``--filename-override`` parameter which allows you to tell

--- a/README.rst
+++ b/README.rst
@@ -382,33 +382,33 @@ Encrypting and decrypting from other programs
 When using ``sops`` in scripts or from other programs, there are often situations where you do not want to write
 encrypted or decrypted data to disk. The best way to avoid this is to pass data to SOPS via stdin, and to let
 SOPS write data to stdout. By default, the encrypt and decrypt operations write data to stdout already. To pass
-data via stdin, you need to pass ``/dev/stdin`` as the input filename. Please note that this only works on
-Unix-like operating systems such as macOS and Linux. On Windows, you have to use named pipes.
+data via stdin, you need to not provide an input filename. For encrpytion, you also must provide the
+``--filename-override`` option with the file's filename. The filename will be used to determine the input and output
+types, and to select the correct creation rule.
 
 To decrypt data, you can simply do:
 
 .. code:: sh
 
-	$ cat encrypted-data | sops decrypt /dev/stdin > decrypted-data
+	$ cat encrypted-data | sops decrypt --filename-override filename.yaml > decrypted-data
 
 To control the input and output format, pass ``--input-type`` and ``--output-type`` as appropriate. By default,
-``sops`` determines the input and output format from the provided filename, which is ``/dev/stdin`` here, and
+``sops`` determines the input and output format from the provided filename, which is the empty string here, and
 thus will use the binary store which expects JSON input and outputs binary data on decryption.
 
 For example, to decrypt YAML data and obtain the decrypted result as YAML, use:
 
 .. code:: sh
 
-	$ cat encrypted-data | sops decrypt --input-type yaml --output-type yaml /dev/stdin > decrypted-data
+	$ cat encrypted-data | sops decrypt --input-type yaml --output-type yaml > decrypted-data
 
 To encrypt, it is important to note that SOPS also uses the filename to look up the correct creation rule from
-``.sops.yaml``. Likely ``/dev/stdin`` will not match a creation rule, or only match the fallback rule without
-``path_regex``, which is usually not what you want. For that, ``sops`` provides the ``--filename-override``
-parameter which allows you to tell SOPS which filename to use to match creation rules:
+``.sops.yaml``. Therefore, you must provide the ``--filename-override`` parameter which allows you to tell
+SOPS which filename to use to match creation rules:
 
 .. code:: sh
 
-	$ echo 'foo: bar' | sops encrypt --filename-override path/filename.sops.yaml /dev/stdin > encrypted-data
+	$ echo 'foo: bar' | sops encrypt --filename-override path/filename.sops.yaml > encrypted-data
 
 SOPS will find a matching creation rule for ``path/filename.sops.yaml`` in ``.sops.yaml`` and use that one to
 encrypt the data from stdin. This filename will also be used to determine the input and output store. As always,
@@ -417,7 +417,7 @@ the input store type can be adjusted by passing ``--input-type``, and the output
 
 .. code:: sh
 
-	$ echo foo=bar | sops encrypt --filename-override path/filename.sops.yaml --input-type dotenv /dev/stdin > encrypted-data
+	$ echo foo=bar | sops encrypt --filename-override path/filename.sops.yaml --input-type dotenv > encrypted-data
 
 
 Encrypting using Hashicorp Vault
@@ -1265,7 +1265,7 @@ When operating on stdin, use the ``--input-type`` and ``--output-type`` flags as
 
 .. code:: sh
 
-    $ cat myfile.json | sops decrypt --input-type json --output-type json /dev/stdin
+    $ cat myfile.json | sops decrypt --input-type json --output-type json
 
 JSON and JSON_binary indentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cmd/sops/common/common.go
+++ b/cmd/sops/common/common.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -130,11 +131,20 @@ func EncryptTree(opts EncryptTreeOpts) error {
 	return nil
 }
 
-// LoadEncryptedFile loads an encrypted SOPS file, returning a SOPS tree
-func LoadEncryptedFile(loader sops.EncryptedFileLoader, inputPath string) (*sops.Tree, error) {
-	fileBytes, err := os.ReadFile(inputPath)
-	if err != nil {
-		return nil, NewExitError(fmt.Sprintf("Error reading file: %s", err), codes.CouldNotReadInputFile)
+// LoadEncryptedFileEx loads an encrypted SOPS file from a file or stdin, returning a SOPS tree
+func LoadEncryptedFileEx(loader sops.EncryptedFileLoader, inputPath string, readFromStdin bool) (*sops.Tree, error) {
+	var fileBytes []byte
+	var err error
+	if readFromStdin {
+		fileBytes, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, NewExitError(fmt.Sprintf("Error reading from stdin: %s", err), codes.CouldNotReadInputFile)
+		}
+	} else {
+		fileBytes, err = os.ReadFile(inputPath)
+		if err != nil {
+			return nil, NewExitError(fmt.Sprintf("Error reading file: %s", err), codes.CouldNotReadInputFile)
+		}
 	}
 	path, err := filepath.Abs(inputPath)
 	if err != nil {
@@ -143,6 +153,11 @@ func LoadEncryptedFile(loader sops.EncryptedFileLoader, inputPath string) (*sops
 	tree, err := loader.LoadEncryptedFile(fileBytes)
 	tree.FilePath = path
 	return &tree, err
+}
+
+// LoadEncryptedFile loads an encrypted SOPS file, returning a SOPS tree
+func LoadEncryptedFile(loader sops.EncryptedFileLoader, inputPath string) (*sops.Tree, error) {
+	return LoadEncryptedFileEx(loader, inputPath, false)
 }
 
 // NewExitError returns a cli.ExitError given an error (wrapped in a generic interface{})
@@ -227,6 +242,7 @@ type GenericDecryptOpts struct {
 	Cipher          sops.Cipher
 	InputStore      sops.Store
 	InputPath       string
+	ReadFromStdin   bool
 	IgnoreMAC       bool
 	KeyServices     []keyservice.KeyServiceClient
 	DecryptionOrder []string
@@ -235,7 +251,7 @@ type GenericDecryptOpts struct {
 // LoadEncryptedFileWithBugFixes is a wrapper around LoadEncryptedFile which includes
 // check for the issue described in https://github.com/mozilla/sops/pull/435
 func LoadEncryptedFileWithBugFixes(opts GenericDecryptOpts) (*sops.Tree, error) {
-	tree, err := LoadEncryptedFile(opts.InputStore, opts.InputPath)
+	tree, err := LoadEncryptedFileEx(opts.InputStore, opts.InputPath, opts.ReadFromStdin)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/sops/decrypt.go
+++ b/cmd/sops/decrypt.go
@@ -19,6 +19,7 @@ type decryptOpts struct {
 	InputStore      sops.Store
 	OutputStore     sops.Store
 	InputPath       string
+	ReadFromStdin   bool
 	IgnoreMAC       bool
 	Extract         []interface{}
 	KeyServices     []keyservice.KeyServiceClient
@@ -27,11 +28,12 @@ type decryptOpts struct {
 
 func decryptTree(opts decryptOpts) (tree *sops.Tree, err error) {
 	tree, err = common.LoadEncryptedFileWithBugFixes(common.GenericDecryptOpts{
-		Cipher:      opts.Cipher,
-		InputStore:  opts.InputStore,
-		InputPath:   opts.InputPath,
-		IgnoreMAC:   opts.IgnoreMAC,
-		KeyServices: opts.KeyServices,
+		Cipher:        opts.Cipher,
+		InputStore:    opts.InputStore,
+		InputPath:     opts.InputPath,
+		ReadFromStdin: opts.ReadFromStdin,
+		IgnoreMAC:     opts.IgnoreMAC,
+		KeyServices:   opts.KeyServices,
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -722,8 +722,8 @@ func main() {
 		},
 		{
 			Name:      "decrypt",
-			Usage:     "decrypt a file, and output the results to stdout",
-			ArgsUsage: `file`,
+			Usage:     "decrypt a file, and output the results to stdout. If no filename is provided, stdin will be used.",
+			ArgsUsage: `[file]`,
 			Flags: append([]cli.Flag{
 				cli.BoolFlag{
 					Name:  "in-place, i",
@@ -751,7 +751,7 @@ func main() {
 				},
 				cli.StringFlag{
 					Name:  "filename-override",
-					Usage: "Use this filename instead of the provided argument for loading configuration, and for determining input type and output type",
+					Usage: "Use this filename instead of the provided argument for loading configuration, and for determining input type and output type. Required when reading from stdin.",
 				},
 				cli.StringFlag{
 					Name:   "decryption-order",
@@ -763,19 +763,24 @@ func main() {
 				if c.Bool("verbose") {
 					logging.SetLevel(logrus.DebugLevel)
 				}
-				if c.NArg() < 1 {
-					return common.NewExitError("Error: no file specified", codes.NoFileSpecified)
+				if c.NArg() == 0 && c.Bool("in-place") {
+					return common.NewExitError("Error: cannot use --in-place when reading from stdin", codes.ErrorConflictingParameters)
 				}
 				warnMoreThanOnePositionalArgument(c)
 				if c.Bool("in-place") && c.String("output") != "" {
 					return common.NewExitError("Error: cannot operate on both --output and --in-place", codes.ErrorConflictingParameters)
 				}
-				fileName, err := filepath.Abs(c.Args()[0])
-				if err != nil {
-					return toExitError(err)
-				}
-				if _, err := os.Stat(fileName); os.IsNotExist(err) {
-					return common.NewExitError(fmt.Sprintf("Error: cannot operate on non-existent file %q", fileName), codes.NoFileSpecified)
+				readFromStdin := c.NArg() == 0
+				var fileName string
+				var err error
+				if !readFromStdin {
+					fileName, err = filepath.Abs(c.Args()[0])
+					if err != nil {
+						return toExitError(err)
+					}
+					if _, err := os.Stat(fileName); os.IsNotExist(err) {
+						return common.NewExitError(fmt.Sprintf("Error: cannot operate on non-existent file %q", fileName), codes.NoFileSpecified)
+					}
 				}
 				fileNameOverride := c.String("filename-override")
 				if fileNameOverride == "" {
@@ -806,6 +811,7 @@ func main() {
 					OutputStore:     outputStore,
 					InputStore:      inputStore,
 					InputPath:       fileName,
+					ReadFromStdin:   readFromStdin,
 					Cipher:          aes.NewCipher(),
 					Extract:         extract,
 					KeyServices:     svcs,
@@ -847,8 +853,8 @@ func main() {
 		},
 		{
 			Name:      "encrypt",
-			Usage:     "encrypt a file, and output the results to stdout",
-			ArgsUsage: `file`,
+			Usage:     "encrypt a file, and output the results to stdout. If no filename is provided, stdin will be used.",
+			ArgsUsage: `[file]`,
 			Flags: append([]cli.Flag{
 				cli.BoolFlag{
 					Name:  "in-place, i",
@@ -926,26 +932,36 @@ func main() {
 				},
 				cli.StringFlag{
 					Name:  "filename-override",
-					Usage: "Use this filename instead of the provided argument for loading configuration, and for determining input type and output type",
+					Usage: "Use this filename instead of the provided argument for loading configuration, and for determining input type and output type. Required when reading from stdin.",
 				},
 			}, keyserviceFlags...),
 			Action: func(c *cli.Context) error {
 				if c.Bool("verbose") {
 					logging.SetLevel(logrus.DebugLevel)
 				}
-				if c.NArg() < 1 {
-					return common.NewExitError("Error: no file specified", codes.NoFileSpecified)
+				if c.NArg() == 0 {
+					if c.Bool("in-place") {
+						return common.NewExitError("Error: cannot use --in-place when reading from stdin", codes.ErrorConflictingParameters)
+					}
+					if c.String("filename-override") == "" {
+						return common.NewExitError("Error: must specify --filename-override when reading from stdin", codes.ErrorConflictingParameters)
+					}
 				}
 				warnMoreThanOnePositionalArgument(c)
 				if c.Bool("in-place") && c.String("output") != "" {
 					return common.NewExitError("Error: cannot operate on both --output and --in-place", codes.ErrorConflictingParameters)
 				}
-				fileName, err := filepath.Abs(c.Args()[0])
-				if err != nil {
-					return toExitError(err)
-				}
-				if _, err := os.Stat(fileName); os.IsNotExist(err) {
-					return common.NewExitError(fmt.Sprintf("Error: cannot operate on non-existent file %q", fileName), codes.NoFileSpecified)
+				readFromStdin := c.NArg() == 0
+				var fileName string
+				var err error
+				if !readFromStdin {
+					fileName, err = filepath.Abs(c.Args()[0])
+					if err != nil {
+						return toExitError(err)
+					}
+					if _, err := os.Stat(fileName); os.IsNotExist(err) {
+						return common.NewExitError(fmt.Sprintf("Error: cannot operate on non-existent file %q", fileName), codes.NoFileSpecified)
+					}
 				}
 				fileNameOverride := c.String("filename-override")
 				if fileNameOverride == "" {
@@ -970,6 +986,7 @@ func main() {
 					OutputStore:   outputStore,
 					InputStore:    inputStore,
 					InputPath:     fileName,
+					ReadFromStdin: readFromStdin,
 					Cipher:        aes.NewCipher(),
 					KeyServices:   svcs,
 					encryptConfig: encConfig,

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -751,7 +751,7 @@ func main() {
 				},
 				cli.StringFlag{
 					Name:  "filename-override",
-					Usage: "Use this filename instead of the provided argument for loading configuration, and for determining input type and output type. Required when reading from stdin.",
+					Usage: "Use this filename instead of the provided argument for loading configuration, and for determining input type and output type. Should be provided when reading from stdin.",
 				},
 				cli.StringFlag{
 					Name:   "decryption-order",
@@ -763,14 +763,14 @@ func main() {
 				if c.Bool("verbose") {
 					logging.SetLevel(logrus.DebugLevel)
 				}
-				if c.NArg() == 0 && c.Bool("in-place") {
+				readFromStdin := c.NArg() == 0
+				if readFromStdin && c.Bool("in-place") {
 					return common.NewExitError("Error: cannot use --in-place when reading from stdin", codes.ErrorConflictingParameters)
 				}
 				warnMoreThanOnePositionalArgument(c)
 				if c.Bool("in-place") && c.String("output") != "" {
 					return common.NewExitError("Error: cannot operate on both --output and --in-place", codes.ErrorConflictingParameters)
 				}
-				readFromStdin := c.NArg() == 0
 				var fileName string
 				var err error
 				if !readFromStdin {
@@ -939,7 +939,8 @@ func main() {
 				if c.Bool("verbose") {
 					logging.SetLevel(logrus.DebugLevel)
 				}
-				if c.NArg() == 0 {
+				readFromStdin := c.NArg() == 0
+				if readFromStdin {
 					if c.Bool("in-place") {
 						return common.NewExitError("Error: cannot use --in-place when reading from stdin", codes.ErrorConflictingParameters)
 					}
@@ -951,7 +952,6 @@ func main() {
 				if c.Bool("in-place") && c.String("output") != "" {
 					return common.NewExitError("Error: cannot operate on both --output and --in-place", codes.ErrorConflictingParameters)
 				}
-				readFromStdin := c.NArg() == 0
 				var fileName string
 				var err error
 				if !readFromStdin {


### PR DESCRIPTION
Allows to encrypt/decrpyt from stdin by providing no input filename to the `encrpyt` and `decrpyt` commands. For `encrypt`, `--filename-override` must be provided in that case to be able to select the proper creation rule.

Fixes #739
Ref: #1104