### PR TITLE
Release 3.9.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,27 @@
 Changelog
 =========
 
+3.9.2
+-----
+
+Improvements:
+
+* Dependency updates (#1645, #1649, #1653, #1662, #1686, #1693).
+* Update compiled Protobuf definitions (#1688).
+* Remove unused variables and simplify conditional (##1687).
+
+Bugfixes:
+
+* Handle whitespace in Azure Key Vault URLs (#1652).
+* Correctly handle comments during JSON serialization (#1647).
+
+Project changes:
+
+* CI dependency updates (#1644, #1648, #1654, #1664, #1673, #1677, #1685).
+* Rust dependency updates (#1655, #1663, #1670, #1676, #1689).
+* Update and improve Protobuf code generation (#1688).
+
+
 3.9.1
 -----
 

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Version represents the value of the current semantic version.
-var Version = "3.9.1"
+var Version = "3.9.2"
 
 // PrintVersion prints the current version of sops. If the flag
 // `--disable-version-check` is set, the function will not attempt


### PR DESCRIPTION
Once #1688 has been merged, I'd like to create a 3.9.2 release. It contains mostly dependency updates and two bugfixes; see the changelog for details.

Will rebase once #1688 has been merged.

Ref: https://github.com/getsops/sops/blob/main/docs/release.md