### PR TITLE
Tests: use alternative container images from public.ecr.aws

### DIFF
--- a/hcvault/keysource_test.go
+++ b/hcvault/keysource_test.go
@@ -41,7 +41,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// Pull the image, create a container based on it, and run it
-	resource, err := pool.Run("vault", testVaultVersion, []string{"VAULT_DEV_ROOT_TOKEN_ID=" + testVaultToken})
+	resource, err := pool.Run("public.ecr.aws/hashicorp/vault", testVaultVersion, []string{"VAULT_DEV_ROOT_TOKEN_ID=" + testVaultToken})
 	if err != nil {
 		logger.Fatalf("could not start resource: %s", err)
 	}

--- a/kms/keysource_test.go
+++ b/kms/keysource_test.go
@@ -33,9 +33,9 @@ const (
 	// testLocalKMSImage is a container image repository reference to a mock
 	// version of AWS' Key Management Service.
 	// Ref: https://github.com/nsmithuk/local-kms
-	testLocalKMSImage = "docker.io/nsmithuk/local-kms"
+	testLocalKMSImage = "public.ecr.aws/nsmithuk/local-kms"
 	// testLocalKMSImage is the container image tag to use.
-	testLocalKMSTag = "3.11.1"
+	testLocalKMSTag = "3.11.7"
 )
 
 // TestMain initializes an AWS KMS server using Docker, writes the HTTP address


### PR DESCRIPTION
Fixes #1667.

We cannot use the identical versions that were used before for nsmithuk/local-kms, since public.ecr.aws has only version 3.11.7, but not version 3.11.1 we used before.

Also vault seems to be more up-to-date on public.ecr.aws than on Docker Hub. This might make a difference.

Let's see what CI says...