### PR TITLE
updatekeys subcommand: fix input-type CLI flag being ignored

### DIFF
--- a/cmd/sops/subcommand/updatekeys/updatekeys.go
+++ b/cmd/sops/subcommand/updatekeys/updatekeys.go
@@ -45,7 +45,7 @@ func updateFile(opts Opts) error {
 	if err != nil {
 		return err
 	}
-	store := common.DefaultStoreForPath(sc, opts.InputPath)
+	store := common.DefaultStoreForPathOrFormat(sc, opts.InputPath, opts.InputType)
 	log.Printf("Syncing keys for file %s", opts.InputPath)
 	tree, err := common.LoadEncryptedFile(store, opts.InputPath)
 	if err != nil {


### PR DESCRIPTION
An adjusted version of @kleinschrader's #1694 that uses `common.DefaultStoreForPathOrFormat()` instead of basically re-implementing that helper function.

Closes #1694