### PR TITLE
Tests: use container images from https://github.com/getsops/ci-container-images

### DIFF
--- a/hcvault/keysource_test.go
+++ b/hcvault/keysource_test.go
@@ -41,7 +41,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// Pull the image, create a container based on it, and run it
-	resource, err := pool.Run("vault", testVaultVersion, []string{"VAULT_DEV_ROOT_TOKEN_ID=" + testVaultToken})
+	resource, err := pool.Run("ghcr.io/getsops/ci-container-images/vault", testVaultVersion, []string{"VAULT_DEV_ROOT_TOKEN_ID=" + testVaultToken})
 	if err != nil {
 		logger.Fatalf("could not start resource: %s", err)
 	}

--- a/kms/keysource_test.go
+++ b/kms/keysource_test.go
@@ -33,7 +33,7 @@ const (
 	// testLocalKMSImage is a container image repository reference to a mock
 	// version of AWS' Key Management Service.
 	// Ref: https://github.com/nsmithuk/local-kms
-	testLocalKMSImage = "docker.io/nsmithuk/local-kms"
+	testLocalKMSImage = "ghcr.io/getsops/ci-container-images/local-kms"
 	// testLocalKMSImage is the container image tag to use.
 	testLocalKMSTag = "3.11.1"
 )


### PR DESCRIPTION
Instead of using images from Docker Hub, use them from the container registry of https://github.com/getsops/ci-container-images.

Fixes #1667