### PR TITLE
YAML: fail loading when timestamp is found

### DIFF
--- a/stores/yaml/store.go
+++ b/stores/yaml/store.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/getsops/sops/v3"
 	"github.com/getsops/sops/v3/config"
@@ -83,6 +84,9 @@ func (store Store) nodeToTreeValue(node *yaml.Node, commentsWereHandled bool) (i
 	case yaml.ScalarNode:
 		var result interface{}
 		node.Decode(&result)
+		if time, ok := result.(time.Time); ok {
+			return nil, fmt.Errorf("Unsupported time element found: %q", time)
+		}
 		return result, nil
 	case yaml.AliasNode:
 		return store.nodeToTreeValue(node.Alias, false)

--- a/stores/yaml/store_test.go
+++ b/stores/yaml/store_test.go
@@ -255,6 +255,13 @@ func TestLoadAliasesPlainFile(t *testing.T) {
 	assert.Equal(t, ALIASES_BRANCHES, branches)
 }
 
+func TestLoadPlainFileTime(t *testing.T) {
+	branches, err := (&Store{}).LoadPlainFile([]byte("foo: 2025-02-15"))
+	assert.NotNil(t, err)
+	assert.Nil(t, branches)
+	assert.Equal(t, `Error unmarshaling input YAML: Unsupported time element found: "2025-02-15 00:00:00 +0000 UTC"`, err.Error())
+}
+
 func TestComment1(t *testing.T) {
 	// First iteration: load and store
 	branches, err := (&Store{}).LoadPlainFile(COMMENT_1)


### PR DESCRIPTION
Right now SOPS does not support timestamps (see also #944), and trying to encrypt a YAML document containing one exits at encryption time (and not load time).

This has the consequence that if you `sops edit` a YAML file and happen to enter a timestamp, then save and exit to let SOPS encrypt it, then it will successfully load the edited file, thus exit the edit loop, but then fail to encrypt, and exit. Thus you won't get back to the editor with a chance to quote the timestamp.

Changing this to a load-time error ensures that you stay in the edit loop and can fix the timestamp in the editor.

(The other formats don't support timetstamps either, so nothing is lost.)

One potential drawback: if the timestamp is not encrypted (due to one of the many options to not encrypt certain values), loading and storing it did work before. (See https://github.com/getsops/sops/issues/944#issuecomment-1875275498.) This makes this potentially a **breaking change**. WDYT?