### PR TITLE
fix(docs): typo in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -523,7 +523,7 @@ disabled by supplying the ``-y`` flag.
 ******************
 
 The ``rotate`` command generates a new data encryption key and reencrypt all values
-with the new key. At te same time, the command line flag ``--add-kms``, ``--add-pgp``,
+with the new key. At the same time, the command line flag ``--add-kms``, ``--add-pgp``,
 ``--add-gcp-kms``, ``--add-azure-kv``, ``--rm-kms``, ``--rm-pgp``, ``--rm-gcp-kms``
 and ``--rm-azure-kv`` can be used to add and remove keys from a file. These flags use
 the comma separated syntax as the ``--kms``, ``--pgp``, ``--gcp-kms`` and ``--azure-kv``


### PR DESCRIPTION
Just a small typo in the docs