### PR TITLE
make sure that tests do not pick keys.txt from user's HOME dir

### DIFF
--- a/age/keysource_test.go
+++ b/age/keysource_test.go
@@ -241,6 +241,7 @@ func TestMasterKey_Decrypt(t *testing.T) {
 	})
 
 	t.Run("loaded identities", func(t *testing.T) {
+		overwriteUserConfigDir(t, t.TempDir())
 		key := &MasterKey{EncryptedKey: mockEncryptedKey}
 		t.Setenv(SopsAgeKeyEnv, mockIdentity)
 
@@ -295,6 +296,7 @@ func TestMasterKey_Decrypt(t *testing.T) {
 	})
 
 	t.Run("invalid encrypted key", func(t *testing.T) {
+		overwriteUserConfigDir(t, t.TempDir())
 		key := &MasterKey{EncryptedKey: "invalid"}
 		t.Setenv(SopsAgeKeyEnv, mockIdentity)
 


### PR DESCRIPTION
Fix 

```
--- FAIL: TestMasterKey_Decrypt (0.02s)
    --- FAIL: TestMasterKey_Decrypt/loaded_identities (0.00s)
        keysource_test.go:254: 
            	Error Trace:	~/git/github/sops/age/keysource_test.go:254
            	Error:      	Received unexpected error:
            	            	failed to load age identities: failed to parse '~/.config/sops/age/keys.txt' age identities: error at line 1: malformed secret key: separator '1' at invalid position: pos=-1, len=34
            	Test:       	TestMasterKey_Decrypt/loaded_identities
        keysource_test.go:255: 
            	Error Trace:	~/git/github/sops/age/keysource_test.go:255
            	Error:      	Not equal: 
            	            	expected: string("data")
            	            	actual  : []uint8([]byte(nil))
            	Test:       	TestMasterKey_Decrypt/loaded_identities
    --- FAIL: TestMasterKey_Decrypt/invalid_encrypted_key (0.00s)
        keysource_test.go:314: 
            	Error Trace: ~/git/github/sops/age/keysource_test.go:314
            	Error:      	Error "failed to load age identities: failed to parse '~/.config/sops/age/keys.txt' age identities: error at line 1: malformed secret key: separator '1' at invalid position: pos=-1, len=34" does not contain "failed to create reader for decrypting sops data key with age"
            	Test:       	TestMasterKey_Decrypt/invalid_encrypted_key
```