### PR TITLE
vendored age code: consolidate passphrase reading functionality

### DIFF
--- a/age/encrypted_keys.go
+++ b/age/encrypted_keys.go
@@ -145,7 +145,7 @@ func unwrapIdentities(key string, reader io.Reader) (ParsedIdentities, error) {
 			Passphrase: func() (string, error) {
 				conn, err := gpgagent.NewConn()
 				if err != nil {
-					passphrase, err := readPassphrase("Enter passphrase for identity " + key + ":")
+					passphrase, err := readSecret("Enter passphrase for identity " + key + ":")
 					if err != nil {
 						return "", err
 					}

--- a/age/ssh_parse.go
+++ b/age/ssh_parse.go
@@ -65,7 +65,7 @@ func parseSSHIdentityFromPrivateKeyFile(keyPath string) (age.Identity, error) {
 			}
 		}
 		passphrasePrompt := func() ([]byte, error) {
-			pass, err := readPassphrase(fmt.Sprintf("Enter passphrase for %q:", keyPath))
+			pass, err := readSecret(fmt.Sprintf("Enter passphrase for %q:", keyPath))
 			if err != nil {
 				return nil, fmt.Errorf("could not read passphrase for %q: %v", keyPath, err)
 			}


### PR DESCRIPTION
Follow-up to #1692 and #1641.

While digging through age's history to figure out why `readPassphrase` vendored in #1692 wasn't there anymore in the latest age version, I noticed that basically readPassphrase was replaced by readSecret in https://github.com/FiloSottile/age/commit/c0e80ef2c985442f957990098ed1cb4b4dd4aa7e. This PR basically does the same, so we can stick to the latest version of cmd/age/tui.go.

Sorry @brianmcgee for the extra work...