### PR TITLE
azkv: Allow specifying auth method and add cachable authentication methods 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/getsops/sops/v3
 
-go 1.22
-toolchain go1.23.6
+go 1.23.0
+
+toolchain go1.24.0
 
 require (
 	cloud.google.com/go/kms v1.21.0
@@ -9,6 +10,7 @@ require (
 	filippo.io/age v1.2.1
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.2
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.2
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.3.1
 	github.com/ProtonMail/go-crypto v1.1.5
 	github.com/aws/aws-sdk-go-v2 v1.36.2
@@ -60,6 +62,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.1.1 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
+	github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.3.3 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.25.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.49.0 // indirect
@@ -112,6 +115,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/keybase/go-keychain v0.0.0-20231219164618-57a3676c3af6 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect


### PR DESCRIPTION
Azure is just really awful and slow to work with, and using sops with a azkv key to edit secrets from e.g. your laptop where you are authenticating with your user and not through a SP/MSI is nightmarishly slow.

To improve the situation this PR implements:
- Allow explicitly specifying auth method through environement variable, this bypass the need to go through the default authentication chain.
- Adds two cachable auth methods `InteractiveBrowserCredential` and `DeviceCodeCredential` which adds a very significant speedup compared to `AzureCliCredential`. See below.

The time to unlock a secret using sops `v3.9.4` and authenticating as a user through `azure-cli`: 
```
time sops -d ./path/to/secret
4.77s user 1.17s system 82% cpu 7.217 total
```

The time to unlock a secret using my PR and authenticating as a user with `InteractiveBrowserCredential` after the initial authentication:
```
> time SOPS_AZURE_AUTH_METHOD="BROWSER" sops -d ./path/to/secret
0.08s user 0.05s system 25% cpu 0.511 total
```

Related issues: #885, #1606 

I'm happy to add documentation, tests or whatever is needed. I just don't want to go through the trouble before I know if the design is acceptable, and that there is a chance that this could be merged.