### PR TITLE
Fix caching of Metadata.DataKey

### DIFF
--- a/sops.go
+++ b/sops.go
@@ -824,7 +824,7 @@ func (m *Metadata) UpdateMasterKeys(dataKey []byte) (errs []error) {
 
 // GetDataKeyWithKeyServices retrieves the data key, asking KeyServices to decrypt it with each
 // MasterKey in the Metadata's KeySources until one of them succeeds.
-func (m Metadata) GetDataKeyWithKeyServices(svcs []keyservice.KeyServiceClient, decryptionOrder []string) ([]byte, error) {
+func (m *Metadata) GetDataKeyWithKeyServices(svcs []keyservice.KeyServiceClient, decryptionOrder []string) ([]byte, error) {
 	if m.DataKey != nil {
 		return m.DataKey, nil
 	}


### PR DESCRIPTION
At the end of the function, the key was stored in `m.DataKey`. Since `m` was a copy of the called object, this did not cache anything.

(Also found with `make staticcheck`; I created a separate PR since this is clearly a bugfix.)