### PR TITLE
If --filename-override is specified, convert it to an absolute path same as regular filenames

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -791,6 +791,11 @@ func main() {
 				fileNameOverride := c.String("filename-override")
 				if fileNameOverride == "" {
 					fileNameOverride = fileName
+				} else {
+					fileNameOverride, err = filepath.Abs(fileNameOverride)
+					if err != nil {
+						return toExitError(err)
+					}
 				}
 
 				inputStore, err := inputStore(c, fileNameOverride)
@@ -972,6 +977,11 @@ func main() {
 				fileNameOverride := c.String("filename-override")
 				if fileNameOverride == "" {
 					fileNameOverride = fileName
+				} else {
+					fileNameOverride, err = filepath.Abs(fileNameOverride)
+					if err != nil {
+						return toExitError(err)
+					}
 				}
 
 				inputStore, err := inputStore(c, fileNameOverride)
@@ -1138,6 +1148,11 @@ func main() {
 				fileNameOverride := c.String("filename-override")
 				if fileNameOverride == "" {
 					fileNameOverride = fileName
+				} else {
+					fileNameOverride, err = filepath.Abs(fileNameOverride)
+					if err != nil {
+						return toExitError(err)
+					}
 				}
 
 				inputStore, err := inputStore(c, fileNameOverride)
@@ -1775,6 +1790,11 @@ func main() {
 		fileNameOverride := c.String("filename-override")
 		if fileNameOverride == "" {
 			fileNameOverride = fileName
+		} else {
+			fileNameOverride, err = filepath.Abs(fileNameOverride)
+			if err != nil {
+				return toExitError(err)
+			}
 		}
 
 		commandCount := 0


### PR DESCRIPTION
Fixes the issue described in https://github.com/ansible-collections/community.sops/issues/226.

If you are in a subdirectory below `.sops.yaml` (say `subdir/`) and use `sops encrypt local_filename.yaml`, it will correctly match `subdir/local_filename.yaml` in `.sops.yaml` if you're using `path_regex: subdir/local_filename\.yaml`. If you use `sops encrypt --filename-override local_filename.yaml`, it will not find the matching encryption rule since it won't match `/path/to/subdir/local_filename.yaml`, but only `local_filename.yaml`.
