### PR TITLE
Add support for `oauth2.TokenSource` in GCP KMS

### DIFF
--- a/gcpkms/keysource_test.go
+++ b/gcpkms/keysource_test.go
@@ -9,6 +9,7 @@ import (
 
 	"cloud.google.com/go/kms/apiv1/kmspb"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -36,6 +37,13 @@ func TestMasterKeysFromResourceIDString(t *testing.T) {
 	if k2.ResourceID != expectedResourceID2 {
 		t.Errorf("ResourceID mismatch. Expected %s, found %s", expectedResourceID2, k2.ResourceID)
 	}
+}
+
+func TestTokenSource_ApplyToMasterKey(t *testing.T) {
+	src := NewTokenSource(oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "some-token"}))
+	key := &MasterKey{}
+	src.ApplyToMasterKey(key)
+	assert.Equal(t, src.source, key.tokenSource)
 }
 
 func TestCredentialJSON_ApplyToMasterKey(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/urfave/cli v1.22.16
 	golang.org/x/crypto v0.36.0
 	golang.org/x/net v0.37.0
+	golang.org/x/oauth2 v0.28.0
 	golang.org/x/sys v0.31.0
 	golang.org/x/term v0.30.0
 	google.golang.org/api v0.227.0
@@ -138,7 +139,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.34.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
-	golang.org/x/oauth2 v0.28.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/time v0.11.0 // indirect


### PR DESCRIPTION
Closes #1792