### PR TITLE
Run go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/getsops/sops/v3
 
-go 1.22
+go 1.23.0
+
 toolchain go1.24.1
 
 require (


### PR DESCRIPTION
Hey,

Because the `go.mod` file is not up to date different upstream packaging software need to rely on weird hacks to build from main branch.

[For example if you look homebrew they by default always need to run](https://github.com/homebrew/homebrew-core/blob/e98c759b61cab72ac15caef771e10a7d44d69de8/Formula/s/sops.rb#L22C5-L22C31):
```sh
$ go mod tidy
```

Because of this I'm also not able to build the current master with nix as seen [in this pretty long thread in nix forums](https://discourse.nixos.org/t/how-to-override-and-build-certain-package-from-master-main-branch/61877/24).

Would it be possible to update this?