### PR TITLE
Warn about `.sops.yml` files found while searching for `.sops.yaml`

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -2189,14 +2189,14 @@ func keyservices(c *cli.Context) (svcs []keyservice.KeyServiceClient) {
 	return
 }
 
-// Wrapper of config.FindConfigFileEx that takes care of handling the returned wraning.
+// Wrapper of config.LookupConfigFile that takes care of handling the returned warning.
 func findConfigFile() (string, error) {
-	configPath, err, warn := config.FindConfigFileEx(".")
-	if len(warn) > 0 && !showedConfigFileWarning {
+	result, err := config.LookupConfigFile(".")
+	if len(result.Warning) > 0 && !showedConfigFileWarning {
 		showedConfigFileWarning = true
-		log.Warn(warn)
+		log.Warn(result.Warning)
 	}
-	return configPath, err
+	return result.Path, err
 }
 
 func loadStoresConfig(context *cli.Context, path string) (*config.StoresConfig, error) {


### PR DESCRIPTION
Some users are confused since they try to create a config file named `.sops.yml` without realizing that it must be called `.sops.yaml`. `sops` does not warn about it, so they spend some time trying to figure out what went wrong.

This prints a message such as
```
[CMD]	 WARN[0000] Ignoring "../.sops.yml" when searching for config file. The config file must be called ".sops.yaml". Found and using "../../.sops.yaml" further up the directory tree instead. 
```
when a real `.sops.yaml` was found somewhere further up than `.sops.yml`, and 
```
[CMD]	 WARN[0000] Ignoring "../.sops.yml" when searching for config file. The config file must be called ".sops.yaml". 
```
when no `.sops.yaml` was found but a `.sops.yml` file.

Closes #1798, which also tried to implement something like this.