### PR TITLE
Remove reserved keyword check from YAML store's `LoadPlainFile()`

### DIFF
--- a/stores/yaml/store.go
+++ b/stores/yaml/store.go
@@ -329,12 +329,6 @@ func (store *Store) LoadPlainFile(in []byte) (sops.TreeBranches, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Error unmarshaling input YAML: %s", err)
 		}
-		// Prevent use of reserved keywords
-		for _, item := range branch {
-			if item.Key == stores.SopsMetadataKey {
-				return nil, fmt.Errorf("YAML doc used reserved word '%v'", item.Key)
-			}
-		}
 		branches = append(branches, branch)
 	}
 	return branches, nil

--- a/stores/yaml/store_test.go
+++ b/stores/yaml/store_test.go
@@ -418,14 +418,3 @@ rootunique:
 	assert.Equal(t, `yaml: unmarshal errors:
   line 3: mapping key "hello" already defined at line 2`, err.Error())
 }
-
-func TestReservedAttributes(t *testing.T) {
-	data := `
-hello: Sops config file
-sops: The attribute 'sops' must be rejected, otherwise the file cannot be opened later on 
-`
-	s := new(Store)
-	_, err := s.LoadPlainFile([]byte(data))
-	assert.NotNil(t, err)
-	assert.Equal(t, `YAML doc used reserved word 'sops'`, err.Error())
-}


### PR DESCRIPTION
This check hid the better (and more general) check in `cmd/sops/encrypt.go` (added in a81f93919c5744fafa180516cea868aa905ebfb0).

The new check was added in adad27e2d4c10d1fb2688bbd3156ef85e1db0735 as part of #1203. I'm not sure why the reserved keyword check was added there, maybe it fixes another thing that the above check does not catch? Do you remember @holiman?

Fixes #1828.
