### PR TITLE
Release 3.10.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 3.10.2
+
+Bugfixes:
+
+* Remove reserved keyword check from YAML store, which hid a better check ([#1829](https://github.com/getsops/sops/pull/1829)).
+
+Improvements:
+
+* Dependency updates ([#1834](https://github.com/getsops/sops/pull/1834), [#1839](https://github.com/getsops/sops/pull/1839)).
+* Use latest 1.24 Go version for release build ([#1836](https://github.com/getsops/sops/pull/1836)).
+
+Project changes:
+
+* CI dependency updates ([#1840](https://github.com/getsops/sops/pull/1840)).
+
 ## 3.10.1
 
 This is a re-release of 3.10.0 with no code changes.

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Version represents the value of the current semantic version.
-var Version = "3.10.1"
+var Version = "3.10.2"
 
 // PrintVersion prints the current version of sops. If the flag
 // `--disable-version-check` is set or if the environment variable


### PR DESCRIPTION
Following https://github.com/getsops/sops/blob/main/docs/release.md.