### PR TITLE
Remove unmatched '`' from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1013,7 +1013,7 @@ service exposed on the unix socket located in ``/tmp/sops.sock``, you can run:
 
 .. code:: sh
 
-    $ sops decrypt --keyservice unix:///tmp/sops.sock file.yaml`
+    $ sops decrypt --keyservice unix:///tmp/sops.sock file.yaml
 
 And if you only want to use the key service exposed on the unix socket located
 in ``/tmp/sops.sock`` and not the local key service, you can run:


### PR DESCRIPTION
This may seem extremely minor, but I'd (jokingly) argue it falls under UX, since I was confused and thought I had dirt on my screen screen due to this lone '`'. It cost me a whole 5s, then another 5m to write this PR, but if it confuses at least 60 people a day then maybe its worth it? Anyways, enjoy this extremely minor change that will hopefully eliminate a silly and still really minor annoyance.