### PR TITLE
Add "--value-file" option to "sops set [...]"

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -1385,6 +1385,10 @@ func main() {
 					Name:  "output-type",
 					Usage: "currently json, yaml, dotenv and binary are supported. If not set, sops will use the input file's extension to determine the output format",
 				},
+				cli.BoolFlag{
+					Name:  "value-file",
+					Usage: "treat 'value' as a file to read the actual value from (avoids leaking secrets in process listings)",
+				},
 				cli.IntFlag{
 					Name:  "shamir-secret-sharing-threshold",
 					Usage: "the number of master keys required to retrieve the data key with shamir",
@@ -1430,7 +1434,18 @@ func main() {
 					return common.NewExitError("Invalid set index format", codes.ErrorInvalidSetFormat)
 				}
 
-				value, err := jsonValueToTreeInsertableValue(c.Args()[2])
+				var data string
+				if c.Bool("value-file") {
+					filename := c.Args()[2]
+					content, err := os.ReadFile(filename)
+					if err != nil {
+						return toExitError(err)
+					}
+					data = string(content)
+				} else {
+					data = c.Args()[2]
+				}
+				value, err := jsonValueToTreeInsertableValue(data)
 				if err != nil {
 					return toExitError(err)
 				}


### PR DESCRIPTION
This allows running "sops set [...]" without leaking secrets in process
listings.

Fixes https://github.com/getsops/sops/issues/729

I'm not a go programmer, please review carefully :-)
