### PR TITLE
Fix Typo in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -250,7 +250,7 @@ Encrypting with SSH keys via age is also supported by SOPS. You can use SSH publ
 ("ssh-ed25519 AAAA...", "ssh-rsa AAAA...") as age recipients when encrypting a file.
 When decrypting a file, SOPS will look for ``~/.ssh/id_ed25519`` and falls back to
 ``~/.ssh/id_rsa``. You can specify the location of the private key manually by setting
-the environment variableuse **SOPS_AGE_SSH_PRIVATE_KEY_FILE**.
+the environment variable **SOPS_AGE_SSH_PRIVATE_KEY_FILE**.
 
 Note that only ``ssh-rsa`` and ``ssh-ed25519`` are supported.
 


### PR DESCRIPTION
Whilst reading the documentation / readme file, I noticed a typo and corrected it.