### PR TITLE
Correct Windows path to store keys.txt

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -234,7 +234,7 @@ configuration directory.
 
 - **Windows**
 
-  - Looks for `keys.txt` in `%AppData%\sops\age\keys.txt`.
+  - Looks for `keys.txt` in `%AppData%\\sops\\age\\keys.txt`.
 
 You can override the default lookup by:
 


### PR DESCRIPTION
The change displays the right path when README.rst is rendered