### PR TITLE
Fix docs: mention all stores instead of just YAML, JSON, and BINARY

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1477,7 +1477,7 @@ original file after encrypting or decrypting it.
 Encrypting binary files
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-SOPS primary use case is encrypting YAML and JSON configuration files, but it
+SOPS primary use case is encrypting YAML, JSON, ENV, and INI configuration files, but it
 also has the ability to manage binary files. When encrypting a binary, SOPS will
 read the data as bytes, encrypt it, store the encrypted base64 under
 ``tree['data']`` and write the result as JSON.
@@ -1611,9 +1611,9 @@ git client interfaces, because they call git diff under the hood!
 Encrypting only parts of a file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Note: this only works on YAML and JSON files, not on BINARY files.
+Note: this only works on YAML, JSON, ENV, and INI files, not on BINARY files.
 
-By default, SOPS encrypts all the values of a YAML or JSON file and leaves the
+By default, SOPS encrypts all the values of a YAML, JSON, ENV, or INI file and leaves the
 keys in cleartext. In some instances, you may want to exclude some values from
 being encrypted. This can be accomplished by adding the suffix **_unencrypted**
 to any key of a file. When set, all values underneath the key that set the
@@ -1824,9 +1824,9 @@ automation, we found this to be a hard problem with a number of prerequisites:
    git repo, jenkins and S3) and only be decrypted on the target
    systems
 
-SOPS can be used to encrypt YAML, JSON and BINARY files. In BINARY mode, the
+SOPS can be used to encrypt YAML, JSON, ENV, INI, and BINARY files. In BINARY mode, the
 content of the file is treated as a blob, the same way PGP would encrypt an
-entire file. In YAML and JSON modes, however, the content of the file is
+entire file. In YAML, JSON, ENV, and INI modes, however, the content of the file is
 manipulated as a tree where keys are stored in cleartext, and values are
 encrypted. hiera-eyaml does something similar, and over the years we learned
 to appreciate its benefits, namely:


### PR DESCRIPTION
There are a few places where only YAML and JSON were mentioned (next to BINARY).

Fixes #1842.