### PR TITLE
feat(azkv): Skipping key-version will get latest key

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -378,6 +378,11 @@ a key. This has the following form::
 
     https://${VAULT_URL}/keys/${KEY_NAME}/${KEY_VERSION}
 
+You can omit the version, and have just a trailing slash, and this will use
+whatever the latest version of the key is::
+
+    https://${VAULT_URL}/keys/${KEY_NAME}/
+
 To create a Key Vault and assign your service principal permissions on it
 from the commandline:
 
@@ -400,6 +405,10 @@ from the commandline:
 Now you can encrypt a file using::
 
     $ sops encrypt --azure-kv https://sops.vault.azure.net/keys/sops-key/some-string test.yaml > test.enc.yaml
+
+or, without the version::
+
+    $ sops encrypt --azure-kv https://sops.vault.azure.net/keys/sops-key/ test.yaml > test.enc.yaml
 
 And decrypt it using::
 

--- a/azkv/keysource.go
+++ b/azkv/keysource.go
@@ -79,7 +79,7 @@ func NewMasterKey(vaultURL string, keyName string, keyVersion string) *MasterKey
 // MasterKey. The URL format is {vaultUrl}/keys/{keyName}/{keyVersion}.
 func NewMasterKeyFromURL(url string) (*MasterKey, error) {
 	url = strings.TrimSpace(url)
-	re := regexp.MustCompile("^(https://[^/]+)/keys/([^/]+)(/[^/]+)?$")
+	re := regexp.MustCompile("^(https://[^/]+)/keys/([^/]+)(/[^/]*)?$")
 	parts := re.FindStringSubmatch(url)
 	if len(parts) < 3 {
 		return nil, fmt.Errorf("could not parse %q into a valid Azure Key Vault MasterKey %v", url, parts)


### PR DESCRIPTION
Firstly: thanks for maintaining such a great tool! It's made my life a lot easier.

Hopefully this PR is helpful in some way; I checked open/closed issues and PRs for something similar being rejected, and couldn't see it.

Anyway, what's the change? I've edited the AZKV implementation to support not including a version in the URL. I.e this makes `https://${VAULT_URL}/keys/${KEY_NAME}/` a valid AZKV URL.

This is a supported behaviour for Azure Key Vault, and is very helpful when it comes to doing rotation of those keys. Updated versions will automatically get fetched by sops for new files with no changes to the config in the repo. This brings AZKV in line with sops' AWS/GCP integrations, which do not require you to specify a key version.

EDIT adding clarification after @felixfontein's comment:
If you _don't_ specify a version in the URL, then sops will use the azkey client (already bundled, of course), to retrieve the specific version of the key, and puts that into the struct instead. I.e even with no version supplied, the [NewMasterKeyFromURL function](https://github.com/getsops/sops/pull/1919/files#diff-17057699dd441d9c5ab351e49afb76566f698c8e4e812e39a052ec8b9f90031dR80) always returns a version, so any files edited/encrypted will still have the specific version stored in the metadata.

>[!NOTE]
>I am not sure how to test this in the automated test suites, as I can't see any comparable test in [azkv/keysource_test.go](https://github.com/getsops/sops/blob/main/azkv/keysource_test.go) that would mock or otherwise inject the az client.
>I am more than happy to be told this is not something sops should even support, or that I need to redo some or all of the work.
>I don't really use golang much day-to-day, so I may be completely missing out on some sensible approach or pattern.

Fixes #1924

## Manual Tests
When no version set in URL, SOPS...
1. **SHOULD** fetch latest version when encrypting a file, and save the version in the file ✅ (seems to parse the URL multiple times though?)
2. **SHOULD NOT** fetch the latest version when editing the file ✅ 
3. **SHOULD NOT** fetch the latest version when decrypting a file ✅ 
4. **SHOULD** fetch the latest and update the file when using `updatekeys` ✅ 

When a version is provided in the URL, SOPS...
1. **SHOULD NOT** fetch it via the client ✅ 
