### PR TITLE
Ignore encryption selection options for binary store (and warn when they are used)

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -2090,7 +2090,12 @@ func getEncryptConfig(c *cli.Context, fileName string, inputStore common.Store, 
 		}
 	}
 
-	if inputStore.IsSingleValueStore() {
+	isSingleValueStore := false
+	if svs, ok := inputStore.(sops.SingleValueStore); ok {
+		isSingleValueStore = svs.IsSingleValueStore()
+	}
+
+	if isSingleValueStore {
 		// Warn about settings that potentially disable encryption of the single key.
 		if unencryptedSuffix != "" {
 			log.Warn(fmt.Sprintf("Using an unencrypted suffix does not make sense with the input store (the %s store produces one key that should always be encrypted) and will be ignored.", inputStore.Name()))
@@ -2142,7 +2147,7 @@ func getEncryptConfig(c *cli.Context, fileName string, inputStore common.Store, 
 	}
 
 	// only supply the default UnencryptedSuffix when EncryptedSuffix, EncryptedRegex, and others are not provided
-	if cryptRuleCount == 0 && !inputStore.IsSingleValueStore() {
+	if cryptRuleCount == 0 && !isSingleValueStore {
 		unencryptedSuffix = sops.DefaultUnencryptedSuffix
 	}
 

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -1023,7 +1023,7 @@ func main() {
 				}
 				svcs := keyservices(c)
 
-				encConfig, err := getEncryptConfig(c, fileNameOverride, nil)
+				encConfig, err := getEncryptConfig(c, fileNameOverride, inputStore, nil)
 				if err != nil {
 					return toExitError(err)
 				}
@@ -1369,7 +1369,7 @@ func main() {
 					}
 				} else {
 					// File doesn't exist, edit the example file instead
-					encConfig, err := getEncryptConfig(c, fileName, nil)
+					encConfig, err := getEncryptConfig(c, fileName, inputStore, nil)
 					if err != nil {
 						return toExitError(err)
 					}
@@ -1908,7 +1908,7 @@ func main() {
 		}
 		var output []byte
 		if isEncryptMode {
-			encConfig, err := getEncryptConfig(c, fileNameOverride, config)
+			encConfig, err := getEncryptConfig(c, fileNameOverride, inputStore, config)
 			if err != nil {
 				return toExitError(err)
 			}
@@ -1996,7 +1996,7 @@ func main() {
 				output, err = edit(opts)
 			} else {
 				// File doesn't exist, edit the example file instead
-				encConfig, err := getEncryptConfig(c, fileNameOverride, config)
+				encConfig, err := getEncryptConfig(c, fileNameOverride, inputStore, config)
 				if err != nil {
 					return toExitError(err)
 				}
@@ -2050,7 +2050,7 @@ func main() {
 	}
 }
 
-func getEncryptConfig(c *cli.Context, fileName string, optionalConfig *config.Config) (encryptConfig, error) {
+func getEncryptConfig(c *cli.Context, fileName string, inputStore common.Store, optionalConfig *config.Config) (encryptConfig, error) {
 	unencryptedSuffix := c.String("unencrypted-suffix")
 	encryptedSuffix := c.String("encrypted-suffix")
 	encryptedRegex := c.String("encrypted-regex")
@@ -2090,6 +2090,33 @@ func getEncryptConfig(c *cli.Context, fileName string, optionalConfig *config.Co
 		}
 	}
 
+	if inputStore.IsSingleValueStore() {
+		// Warn about settings that potentially disable encryption of the single key.
+		if unencryptedSuffix != "" {
+			log.Warn(fmt.Sprintf("Using an unencrypted suffix does not make sense with the input store (the %s store produces one key that should always be encrypted) and will be ignored.", inputStore.Name()))
+		}
+		if encryptedSuffix != "" {
+			log.Warn(fmt.Sprintf("Using an encrypted suffix does not make sense with the input store (the %s store produces one key that should always be encrypted) and will be ignored.", inputStore.Name()))
+		}
+		if encryptedRegex != "" {
+			log.Warn(fmt.Sprintf("Using an encrypted regex does not make sense with the input store (the %s store produces one key that should always be encrypted) and will be ignored.", inputStore.Name()))
+		}
+		if unencryptedRegex != "" {
+			log.Warn(fmt.Sprintf("Using an unencrypted regex does not make sense with the input store (the %s store produces one key that should always be encrypted) and will be ignored.", inputStore.Name()))
+		}
+		if encryptedCommentRegex != "" {
+			log.Warn(fmt.Sprintf("Using an encrypted comment regex does not make sense with the input store (the %s store never produces comments) and will be ignored.", inputStore.Name()))
+		}
+		// Do not warn about unencryptedCommentRegex and macOnlyEncrypted since they cannot have any effect.
+		unencryptedSuffix = ""
+		encryptedSuffix = ""
+		encryptedRegex = ""
+		unencryptedRegex = ""
+		encryptedCommentRegex = ""
+		unencryptedCommentRegex = ""
+		macOnlyEncrypted = false
+	}
+
 	cryptRuleCount := 0
 	if unencryptedSuffix != "" {
 		cryptRuleCount++
@@ -2115,7 +2142,7 @@ func getEncryptConfig(c *cli.Context, fileName string, optionalConfig *config.Co
 	}
 
 	// only supply the default UnencryptedSuffix when EncryptedSuffix, EncryptedRegex, and others are not provided
-	if cryptRuleCount == 0 {
+	if cryptRuleCount == 0 && !inputStore.IsSingleValueStore() {
 		unencryptedSuffix = sops.DefaultUnencryptedSuffix
 	}
 

--- a/sops.go
+++ b/sops.go
@@ -726,12 +726,6 @@ type CheckEncrypted interface {
 	HasSopsTopLevelKey(TreeBranch) bool
 }
 
-// SingleValueStore is the interface for determining whether a store uses only
-// one single key and no comments. This is basically identifying the binary store.
-type SingleValueStore interface {
-	IsSingleValueStore() bool
-}
-
 // Store is used to interact with files, both encrypted and unencrypted.
 type Store interface {
 	EncryptedFileLoader
@@ -740,8 +734,14 @@ type Store interface {
 	PlainFileEmitter
 	ValueEmitter
 	CheckEncrypted
-	SingleValueStore
 	Name() string
+}
+
+// SingleValueStore is the interface for determining whether a store uses only
+// one single key and no comments. This is basically identifying the binary store.
+type SingleValueStore interface {
+	Store
+	IsSingleValueStore() bool
 }
 
 // MasterKeyCount returns the number of master keys available

--- a/sops.go
+++ b/sops.go
@@ -726,6 +726,12 @@ type CheckEncrypted interface {
 	HasSopsTopLevelKey(TreeBranch) bool
 }
 
+// SingleValueStore is the interface for determining whether a store uses only
+// one single key and no comments. This is basically identifying the binary store.
+type SingleValueStore interface {
+	IsSingleValueStore() bool
+}
+
 // Store is used to interact with files, both encrypted and unencrypted.
 type Store interface {
 	EncryptedFileLoader
@@ -734,6 +740,8 @@ type Store interface {
 	PlainFileEmitter
 	ValueEmitter
 	CheckEncrypted
+	SingleValueStore
+	Name() string
 }
 
 // MasterKeyCount returns the number of master keys available

--- a/stores/dotenv/store.go
+++ b/stores/dotenv/store.go
@@ -23,10 +23,6 @@ func NewStore(c *config.DotenvStoreConfig) *Store {
 	return &Store{config: *c}
 }
 
-func (store *Store) IsSingleValueStore() bool {
-	return false
-}
-
 func (store *Store) Name() string {
 	return "dotenv"
 }

--- a/stores/dotenv/store.go
+++ b/stores/dotenv/store.go
@@ -23,6 +23,14 @@ func NewStore(c *config.DotenvStoreConfig) *Store {
 	return &Store{config: *c}
 }
 
+func (store *Store) IsSingleValueStore() bool {
+	return false
+}
+
+func (store *Store) Name() string {
+	return "dotenv"
+}
+
 // LoadEncryptedFile loads an encrypted file's bytes onto a sops.Tree runtime object
 func (store *Store) LoadEncryptedFile(in []byte) (sops.Tree, error) {
 	branches, err := store.LoadPlainFile(in)

--- a/stores/ini/store.go
+++ b/stores/ini/store.go
@@ -21,10 +21,6 @@ func NewStore(c *config.INIStoreConfig) *Store {
 	return &Store{config: c}
 }
 
-func (store *Store) IsSingleValueStore() bool {
-	return false
-}
-
 func (store *Store) Name() string {
 	return "ini"
 }

--- a/stores/ini/store.go
+++ b/stores/ini/store.go
@@ -21,6 +21,14 @@ func NewStore(c *config.INIStoreConfig) *Store {
 	return &Store{config: c}
 }
 
+func (store *Store) IsSingleValueStore() bool {
+	return false
+}
+
+func (store *Store) Name() string {
+	return "ini"
+}
+
 func (store Store) encodeTree(branches sops.TreeBranches) ([]byte, error) {
 	iniFile := ini.Empty(ini.LoadOptions{AllowNonUniqueSections: true})
 	iniFile.DeleteSection(ini.DefaultSection)

--- a/stores/json/store.go
+++ b/stores/json/store.go
@@ -22,10 +22,27 @@ func NewStore(c *config.JSONStoreConfig) *Store {
 	return &Store{config: *c}
 }
 
+func (store *Store) IsSingleValueStore() bool {
+	return false
+}
+
+func (store *Store) Name() string {
+	return "json"
+}
+
 // BinaryStore handles storage of binary data in a JSON envelope.
 type BinaryStore struct {
 	store  Store
 	config config.JSONBinaryStoreConfig
+}
+
+// The binary store uses a single key ("data") to store everything.
+func (store *BinaryStore) IsSingleValueStore() bool {
+	return true
+}
+
+func (store *BinaryStore) Name() string {
+	return "binary"
 }
 
 func NewBinaryStore(c *config.JSONBinaryStoreConfig) *BinaryStore {

--- a/stores/json/store.go
+++ b/stores/json/store.go
@@ -22,10 +22,6 @@ func NewStore(c *config.JSONStoreConfig) *Store {
 	return &Store{config: *c}
 }
 
-func (store *Store) IsSingleValueStore() bool {
-	return false
-}
-
 func (store *Store) Name() string {
 	return "json"
 }

--- a/stores/yaml/store.go
+++ b/stores/yaml/store.go
@@ -24,6 +24,14 @@ func NewStore(c *config.YAMLStoreConfig) *Store {
 	return &Store{config: *c}
 }
 
+func (store *Store) IsSingleValueStore() bool {
+	return false
+}
+
+func (store *Store) Name() string {
+	return "yaml"
+}
+
 func (store Store) appendCommentToList(comment string, list []interface{}) []interface{} {
 	if comment != "" {
 		for _, commentLine := range strings.Split(comment, "\n") {

--- a/stores/yaml/store.go
+++ b/stores/yaml/store.go
@@ -24,10 +24,6 @@ func NewStore(c *config.YAMLStoreConfig) *Store {
 	return &Store{config: *c}
 }
 
-func (store *Store) IsSingleValueStore() bool {
-	return false
-}
-
 func (store *Store) Name() string {
 	return "yaml"
 }


### PR DESCRIPTION
It happened more than once that someone "encrypted" a file using the binary store, which resulted in simply base64 encoding the source since encryption was essentially disabled since some encryption selection option prevented the `data` key to be encrypted.

This PR allows to identify input stores that yield a single key (without comments), and disables all selection options in this case. It also prints warnings for options that potentially disable encryption.

Regarding the warnings: we could also simply not print any warning (might be less annoying to users who simply want to use the same config everywhere), or make the warnings more specific (if they match the `data` key; for that we need to provide the key name as well). @getsops/maintainers what do you think?

Fixes #1822.