### PR TITLE
Fix converting integers to strings; also improve time.Time formatting

### DIFF
--- a/stores/ini/store.go
+++ b/stores/ini/store.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"strconv"
 	"strings"
@@ -80,14 +81,16 @@ func (store Store) stripCommentChar(comment string) string {
 
 func (store Store) valToString(v interface{}) string {
 	switch v := v.(type) {
-	case fmt.Stringer:
-		return v.String()
 	case float64:
 		return strconv.FormatFloat(v, 'f', 6, 64)
 	case bool:
 		return strconv.FormatBool(v)
+	case time.Time:
+		return v.Format(time.RFC3339)
+	case fmt.Stringer:
+		return v.String()
 	default:
-		return fmt.Sprintf("%s", v)
+		return fmt.Sprintf("%v", v)
 	}
 }
 


### PR DESCRIPTION
Before:
```ini
[section]
int       = %!s(int=123)
float     = 1.230000
bool      = true
date      = 2025-01-01 00:00:00 +0000 UTC
timestamp = 2025-01-01 01:02:03 +0000 UTC
string    = this is a string
```

After:
```ini
[section]
int       = 123
float     = 1.230000
bool      = true
date      = 2025-01-01T00:00:00Z
timestamp = 2025-01-01T01:02:03Z
string    = this is a string
```

Fixes #1915.