### PR TITLE
fix logic that checks for multiple destinations

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -508,7 +508,18 @@ func parseDestinationRuleForFile(conf *configFile, filePath string, kmsEncryptio
 	}
 
 	var dest publish.Destination
-	if dRule.S3Bucket != "" && dRule.GCSBucket != "" && dRule.VaultPath != "" {
+	destinationCount := 0
+	if dRule.S3Bucket != "" {
+		destinationCount++
+	}
+	if dRule.GCSBucket != "" {
+		destinationCount++
+	}
+	if dRule.VaultPath != "" {
+		destinationCount++
+	}
+
+	if destinationCount > 1 {
 		return nil, fmt.Errorf("error loading config: more than one destinations were found in a single destination rule, you can only use one per rule")
 	}
 	if dRule.S3Bucket != "" {


### PR DESCRIPTION
The destination validation logic contained a bug that only detected conflicts when all three destination types were specified simultaneously.  This pull request improves validation logic for destination rules in the configuration, ensuring that only one destination (S3, GCS, or Vault) can be specified per rule. It also adds comprehensive tests to verify that the validation behaves correctly for both valid and invalid configurations.

### Validation logic enhancements

* Updated `parseDestinationRuleForFile` in `config/config.go` to count the number of specified destinations and return an error if more than one is set in a single rule. This replaces the previous check that only triggered if all three destinations were set, making the validation more robust.

### Test coverage improvements

* Added multiple test cases in `config/config_test.go` to verify that configurations with more than one destination (S3+GCS, S3+Vault, GCS+Vault, or all three) correctly fail validation, and that configurations with only one destination (S3, GCS, or Vault) pass validation.