### PR TITLE
CI: Build with Go 1.24 and 1.25, release with 1.25

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [linux, darwin, windows]
         arch: [amd64, arm64]
-        go-version: ['1.23', '1.24']
+        go-version: ['1.24', '1.25']
         exclude:
           - os: windows
             arch: arm64
@@ -85,7 +85,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        go-version: ['1.24']
+        go-version: ['1.25']
     env:
       VAULT_VERSION: "1.14.0"
       VAULT_TOKEN: "root"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v4.0.1
         with:
-          go-version: 1.24
+          go-version: 1.25
           cache: false
 
       - name: Setup Syft

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsops/sops/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/kms v1.22.0


### PR DESCRIPTION
Ref: https://github.com/getsops/sops/pull/1941#discussion_r2338482230

@getsops/maintainers or should we keep Go 1.23 in the matrix?