### PR TITLE
AZKV: Also allow to omit version for AZKV keys specified in key groups

### DIFF
--- a/azkv/keysource.go
+++ b/azkv/keysource.go
@@ -64,15 +64,23 @@ type MasterKey struct {
 	clientOptions *azkeys.ClientOptions
 }
 
-// NewMasterKey creates a new MasterKey from a URL, key name and version,
+// newMasterKey creates a new MasterKey from a URL, key name and version,
 // setting the creation date to the current date.
-func NewMasterKey(vaultURL string, keyName string, keyVersion string) *MasterKey {
+func newMasterKey(vaultURL string, keyName string, keyVersion string) *MasterKey {
 	return &MasterKey{
 		VaultURL:     vaultURL,
 		Name:         keyName,
 		Version:      keyVersion,
 		CreationDate: time.Now().UTC(),
 	}
+}
+
+// NewMasterKey creates a new MasterKey from a URL, key name and (optional) version,
+// setting the creation date to the current date.
+func NewMasterKey(vaultURL string, keyName string, keyVersion string) (*MasterKey, error) {
+	key := newMasterKey(vaultURL, keyName, keyVersion)
+	err := key.ensureKeyHasVersion(context.Background())
+	return key, err
 }
 
 // NewMasterKeyFromURL takes an Azure Key Vault key URL, and returns a new
@@ -88,9 +96,9 @@ func NewMasterKeyFromURL(url string) (*MasterKey, error) {
 	// version of the key. We need to put the actual version in the sops metadata block though
 	var key *MasterKey
 	if len(parts[3]) > 1 {
-		key = NewMasterKey(parts[1], parts[2], parts[3][1:])
+		key = newMasterKey(parts[1], parts[2], parts[3][1:])
 	} else {
-		key = NewMasterKey(parts[1], parts[2], "")
+		key = newMasterKey(parts[1], parts[2], "")
 	}
 	err := key.ensureKeyHasVersion(context.Background())
 	return key, err

--- a/azkv/keysource.go
+++ b/azkv/keysource.go
@@ -75,12 +75,20 @@ func newMasterKey(vaultURL string, keyName string, keyVersion string) *MasterKey
 	}
 }
 
+// NewMasterKey creates a new MasterKey from a URL, key name and (mandatory) version,
+// setting the creation date to the current date.
+func NewMasterKey(vaultURL string, keyName string, keyVersion string) *MasterKey {
+	return newMasterKey(vaultURL, keyName, keyVersion)
+}
+
 // NewMasterKey creates a new MasterKey from a URL, key name and (optional) version,
 // setting the creation date to the current date.
-func NewMasterKey(vaultURL string, keyName string, keyVersion string) (*MasterKey, error) {
+func NewMasterKeyWithOptionalVersion(vaultURL string, keyName string, keyVersion string) (*MasterKey, error) {
 	key := newMasterKey(vaultURL, keyName, keyVersion)
-	err := key.ensureKeyHasVersion(context.Background())
-	return key, err
+	if err := key.ensureKeyHasVersion(context.Background()); err != nil {
+		return nil, err
+	}
+	return key, nil
 }
 
 // NewMasterKeyFromURL takes an Azure Key Vault key URL, and returns a new

--- a/azkv/keysource_test.go
+++ b/azkv/keysource_test.go
@@ -181,7 +181,7 @@ func TestMasterKey_EncryptIfNeeded(t *testing.T) {
 }
 
 func TestMasterKey_NeedsRotation(t *testing.T) {
-	key := NewMasterKey("", "", "")
+	key := newMasterKey("", "", "")
 	assert.False(t, key.NeedsRotation())
 
 	key.CreationDate = key.CreationDate.Add(-(azkvTTL + time.Second))
@@ -189,7 +189,7 @@ func TestMasterKey_NeedsRotation(t *testing.T) {
 }
 
 func TestMasterKey_ToString(t *testing.T) {
-	key := NewMasterKey("https://test.vault.azure.net", "key-name", "key-version")
+	key := newMasterKey("https://test.vault.azure.net", "key-name", "key-version")
 	assert.Equal(t, "https://test.vault.azure.net/keys/key-name/key-version", key.ToString())
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -330,7 +330,11 @@ func extractMasterKeys(group keyGroup) (sops.KeyGroup, error) {
 		keyGroup = append(keyGroup, gcpkms.NewMasterKeyFromResourceID(k.ResourceID))
 	}
 	for _, k := range group.AzureKV {
-		keyGroup = append(keyGroup, azkv.NewMasterKey(k.VaultURL, k.Key, k.Version))
+		if key, err := azkv.NewMasterKey(k.VaultURL, k.Key, k.Version); err == nil {
+			keyGroup = append(keyGroup, key)
+		} else {
+			return nil, err
+		}
 	}
 	for _, k := range group.Vault {
 		if masterKey, err := hcvault.NewMasterKeyFromURI(k); err == nil {

--- a/config/config.go
+++ b/config/config.go
@@ -330,7 +330,7 @@ func extractMasterKeys(group keyGroup) (sops.KeyGroup, error) {
 		keyGroup = append(keyGroup, gcpkms.NewMasterKeyFromResourceID(k.ResourceID))
 	}
 	for _, k := range group.AzureKV {
-		if key, err := azkv.NewMasterKey(k.VaultURL, k.Key, k.Version); err == nil {
+		if key, err := azkv.NewMasterKeyWithOptionalVersion(k.VaultURL, k.Key, k.Version); err == nil {
 			keyGroup = append(keyGroup, key)
 		} else {
 			return nil, err


### PR DESCRIPTION
Follow-up to #1919.

While working on #1946, I noticed that #1919 did not handle keys specified in key groups (which already have to be split up into their three parts).

CC @daogilvie @r4vi