### PR TITLE
fix: Add decryption-order flag to exec-env, exec-file, and publish commands

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -196,6 +196,11 @@ func main() {
 					Name:  "same-process",
 					Usage: "run command in the current process instead of in a child process",
 				},
+				cli.StringFlag{
+					Name:   "decryption-order",
+					Usage:  "comma separated list of decryption key types",
+					EnvVar: "SOPS_DECRYPTION_ORDER",
+				},
 			}, keyserviceFlags...),
 			Action: func(c *cli.Context) error {
 				if c.NArg() != 2 {
@@ -305,6 +310,11 @@ func main() {
 					Name:  "filename",
 					Usage: fmt.Sprintf("filename for the temporarily file (default: %s)", exec.FallbackFilename),
 				},
+				cli.StringFlag{
+					Name:   "decryption-order",
+					Usage:  "comma separated list of decryption key types",
+					EnvVar: "SOPS_DECRYPTION_ORDER",
+				},
 			}, keyserviceFlags...),
 			Action: func(c *cli.Context) error {
 				if c.NArg() != 2 {
@@ -382,6 +392,11 @@ func main() {
 				cli.BoolFlag{
 					Name:  "verbose",
 					Usage: "Enable verbose logging output",
+				},
+				cli.StringFlag{
+					Name:   "decryption-order",
+					Usage:  "comma separated list of decryption key types",
+					EnvVar: "SOPS_DECRYPTION_ORDER",
 				},
 			}, keyserviceFlags...),
 			Action: func(c *cli.Context) error {


### PR DESCRIPTION
These commands were referencing the `decryption-order` option but not actually declaring it as a flag. This commit adds the flag to these commands, allowing users to specify the order in which decryption methods are attempted, just like with "sops -d".