### PR TITLE
Add REST client support for GCP KMS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -309,6 +309,14 @@ Or if you are logged in you can authorize by generating an access token:
 
     $ export GOOGLE_OAUTH_ACCESS_TOKEN="$(gcloud auth print-access-token)"
 
+By default, SOPS uses the gRPC client to communicate with GCP KMS. You can optionally
+switch to the REST client by setting the ``SOPS_GCP_KMS_CLIENT_TYPE`` environment variable:
+
+.. code:: sh
+
+    $ export SOPS_GCP_KMS_CLIENT_TYPE=rest  # Use REST client
+    $ export SOPS_GCP_KMS_CLIENT_TYPE=grpc  # Use gRPC client (default)
+
 Encrypting/decrypting with GCP KMS requires a KMS ResourceID. You can use the
 cloud console the get the ResourceID or you can create one using the gcloud
 sdk:


### PR DESCRIPTION
Add SOPS_GCP_KMS_CLIENT_TYPE environment variable support

### Summary
This PR adds support for selecting GCP KMS client type (gRPC or REST) via the `SOPS_GCP_KMS_CLIENT_TYPE` environment variable.

### Motivation
Currently, the client type is hardcoded, making it difficult to integrate with different environments. This change provides flexibility while maintaining backward compatibility. Additionally, selecting the REST client can help avoid errors that occur when SOPS operates through a VPN, addressing the issues outlined in issue #1570 .

### Changes
- Added `SOPS_GCP_KMS_CLIENT_TYPE` environment variable support
- Default behavior: gRPC client (when not set or set to 'grpc')
- REST client: when set to 'rest'
- Updated README.rst with usage examples

### Backward Compatibility
- Fully backward compatible
- Default behavior uses gRPC client
- No breaking changes
