### PR TITLE
wrong word usage decryption > encryption

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -917,7 +917,7 @@ func main() {
 				},
 				cli.StringFlag{
 					Name:  "output",
-					Usage: "Save the output after decryption to the file specified",
+					Usage: "Save the output after encryption to the file specified",
 				},
 				cli.StringFlag{
 					Name:   "kms, k",


### PR DESCRIPTION
Stumbled upon this after mulling over `sops encrypt file > file.enc` vs `sops encrypt file --output file.enc` and both options don't warn me when overwriting an existing file.