### PR TITLE
Fix recursive publish

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -448,6 +448,7 @@ func main() {
 						err = publishcmd.Run(publishcmd.Opts{
 							ConfigPath:      configPath,
 							InputPath:       subPath,
+							RootPath:        path,
 							Cipher:          aes.NewCipher(),
 							KeyServices:     keyservices(c),
 							DecryptionOrder: order,


### PR DESCRIPTION
Currently, the `publish` subcommand with the `--recursive` option is not configured properly and will cause errors. This enhancement resolves the issue