### PR TITLE
Fix KMS encryption context not being passed when config is pre-loaded

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -1901,7 +1901,8 @@ func main() {
 		needsCreationRule := isEncryptMode || isRotateMode || isSetMode || isEditMode
 		var config *config.Config
 		if needsCreationRule {
-			config, err = loadConfig(c, fileNameOverride, nil)
+			kmsEncryptionContext := kms.ParseKMSContext(c.String("encryption-context"))
+			config, err = loadConfig(c, fileNameOverride, kmsEncryptionContext)
 			if err != nil {
 				return toExitError(err)
 			}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -879,3 +879,31 @@ destination_rules:
 	assert.NotNil(t, conf.Destination)
 	assert.Contains(t, conf.Destination.Path("secrets.yaml"), "https://vault.example.com/v1/secret/data/secret/sops/secrets.yaml")
 }
+
+// TestKeyGroupsForFileWithExternalEncryptionContext tests that when kmsEncryptionContext
+// is passed to parseCreationRuleForFile, the resulting KMS keys have the encryption context set.
+// This is a regression test for https://github.com/getsops/sops/issues/1972
+func TestKeyGroupsForFileWithExternalEncryptionContext(t *testing.T) {
+	// Config with flat KMS format (not key_groups) - this is where external context applies
+	var sampleConfigWithFlatKMS = []byte(`
+creation_rules:
+  - path_regex: ""
+    kms: "arn:aws:kms:us-west-2:123456789012:key/12345678-1234-1234-1234-123456789012"
+`)
+
+	// External encryption context passed via --encryption-context flag
+	appName := "myapp"
+	kmsEncryptionContext := map[string]*string{
+		"AppName": &appName,
+	}
+
+	conf, err := parseCreationRuleForFile(parseConfigFile(sampleConfigWithFlatKMS, t), "/conf/path", "secrets.yaml", kmsEncryptionContext)
+	assert.Nil(t, err)
+	assert.NotNil(t, conf)
+	assert.Equal(t, 1, len(conf.KeyGroups))
+	assert.Equal(t, 1, len(conf.KeyGroups[0]))
+
+	// The KMS key should have the encryption context applied
+	// Format: ARN|context where context is "AppName:myapp"
+	assert.Equal(t, "arn:aws:kms:us-west-2:123456789012:key/12345678-1234-1234-1234-123456789012|AppName:myapp", conf.KeyGroups[0][0].ToString())
+}


### PR DESCRIPTION
## Summary

Fixes #1972

In commit 84c767353ad, the config loading was refactored to load only once for performance. However, this introduced a bug where the `kmsEncryptionContext` (from the `--encryption-context` CLI flag) was not passed to `loadConfig()` when pre-loading the config.

This caused KMS master keys in the config's KeyGroups to be created without the encryption context, leading to AWS KMS denying requests when the KMS policy requires an encryption context.

## Changes

- **cmd/sops/main.go**: Parse and pass the `kmsEncryptionContext` when pre-loading the config in `main()`
- **config/config_test.go**: Add regression test `TestKeyGroupsForFileWithExternalEncryptionContext`

## Test plan

- [x] Added regression test that verifies encryption context is applied to KMS keys when passed to config loading
- [x] All existing config tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)