### PR TITLE
feat: add TOML store

### DIFF
--- a/cmd/sops/common/common.go
+++ b/cmd/sops/common/common.go
@@ -18,6 +18,7 @@ import (
 	"github.com/getsops/sops/v3/stores/dotenv"
 	"github.com/getsops/sops/v3/stores/ini"
 	"github.com/getsops/sops/v3/stores/json"
+	"github.com/getsops/sops/v3/stores/toml"
 	"github.com/getsops/sops/v3/stores/yaml"
 	"github.com/getsops/sops/v3/version"
 	"github.com/mitchellh/go-wordwrap"
@@ -59,12 +60,17 @@ func newYamlStore(c *config.StoresConfig) Store {
 	return yaml.NewStore(&c.YAML)
 }
 
+func newTomlStore(c *config.StoresConfig) Store {
+	return toml.NewStore(&c.TOML)
+}
+
 var storeConstructors = map[Format]storeConstructor{
 	Binary: newBinaryStore,
 	Dotenv: newDotenvStore,
 	Ini:    newIniStore,
 	Json:   newJsonStore,
 	Yaml:   newYamlStore,
+	Toml:   newTomlStore,
 }
 
 // DecryptTreeOpts are the options needed to decrypt a tree

--- a/cmd/sops/common/common.go
+++ b/cmd/sops/common/common.go
@@ -56,12 +56,12 @@ func newJsonStore(c *config.StoresConfig) Store {
 	return json.NewStore(&c.JSON)
 }
 
-func newYamlStore(c *config.StoresConfig) Store {
-	return yaml.NewStore(&c.YAML)
-}
-
 func newTomlStore(c *config.StoresConfig) Store {
 	return toml.NewStore(&c.TOML)
+}
+
+func newYamlStore(c *config.StoresConfig) Store {
+	return yaml.NewStore(&c.YAML)
 }
 
 var storeConstructors = map[Format]storeConstructor{
@@ -69,8 +69,8 @@ var storeConstructors = map[Format]storeConstructor{
 	Dotenv: newDotenvStore,
 	Ini:    newIniStore,
 	Json:   newJsonStore,
-	Yaml:   newYamlStore,
 	Toml:   newTomlStore,
+	Yaml:   newYamlStore,
 }
 
 // DecryptTreeOpts are the options needed to decrypt a tree

--- a/cmd/sops/formats/formats.go
+++ b/cmd/sops/formats/formats.go
@@ -11,6 +11,7 @@ const (
 	Ini
 	Json
 	Yaml
+	Toml
 )
 
 var stringToFormat = map[string]Format{
@@ -19,6 +20,7 @@ var stringToFormat = map[string]Format{
 	"ini":    Ini,
 	"json":   Json,
 	"yaml":   Yaml,
+	"toml":   Toml,
 }
 
 // FormatFromString returns a Format from a string.

--- a/cmd/sops/formats/formats.go
+++ b/cmd/sops/formats/formats.go
@@ -10,8 +10,8 @@ const (
 	Dotenv
 	Ini
 	Json
-	Yaml
 	Toml
+	Yaml
 )
 
 var stringToFormat = map[string]Format{
@@ -19,8 +19,8 @@ var stringToFormat = map[string]Format{
 	"dotenv": Dotenv,
 	"ini":    Ini,
 	"json":   Json,
-	"yaml":   Yaml,
 	"toml":   Toml,
+	"yaml":   Yaml,
 }
 
 // FormatFromString returns a Format from a string.

--- a/config/config.go
+++ b/config/config.go
@@ -111,19 +111,19 @@ type JSONBinaryStoreConfig struct {
 	Indent int `yaml:"indent"`
 }
 
+type TOMLStoreConfig struct{}
+
 type YAMLStoreConfig struct {
 	Indent int `yaml:"indent"`
 }
-
-type TOMLStoreConfig struct{}
 
 type StoresConfig struct {
 	Dotenv     DotenvStoreConfig     `yaml:"dotenv"`
 	INI        INIStoreConfig        `yaml:"ini"`
 	JSONBinary JSONBinaryStoreConfig `yaml:"json_binary"`
 	JSON       JSONStoreConfig       `yaml:"json"`
-	YAML       YAMLStoreConfig       `yaml:"yaml"`
 	TOML       TOMLStoreConfig       `yaml:"toml"`
+	YAML       YAMLStoreConfig       `yaml:"yaml"`
 }
 
 type configFile struct {

--- a/config/config.go
+++ b/config/config.go
@@ -115,12 +115,15 @@ type YAMLStoreConfig struct {
 	Indent int `yaml:"indent"`
 }
 
+type TOMLStoreConfig struct{}
+
 type StoresConfig struct {
 	Dotenv     DotenvStoreConfig     `yaml:"dotenv"`
 	INI        INIStoreConfig        `yaml:"ini"`
 	JSONBinary JSONBinaryStoreConfig `yaml:"json_binary"`
 	JSON       JSONStoreConfig       `yaml:"json"`
 	YAML       YAMLStoreConfig       `yaml:"yaml"`
+	TOML       TOMLStoreConfig       `yaml:"toml"`
 }
 
 type configFile struct {

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/ory/dockertest/v3 v3.12.0
+	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/ory/dockertest/v3 v3.12.0
-	github.com/pelletier/go-toml v1.9.5
+	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -293,8 +293,8 @@ github.com/opencontainers/runc v1.2.8 h1:RnEICeDReapbZ5lZEgHvj7E9Q3Eex9toYmaGBsb
 github.com/opencontainers/runc v1.2.8/go.mod h1:cC0YkmZcuvr+rtBZ6T7NBoVbMGNAdLa/21vIElJDOzI=
 github.com/ory/dockertest/v3 v3.12.0 h1:3oV9d0sDzlSQfHtIaB5k6ghUCVMVLpAY8hwrqoCyRCw=
 github.com/ory/dockertest/v3 v3.12.0/go.mod h1:aKNDTva3cp8dwOWwb9cWuX84aH5akkxXRvO7KCwWVjE=
-github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
-github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
+github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
+github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/go.sum
+++ b/go.sum
@@ -293,6 +293,8 @@ github.com/opencontainers/runc v1.2.8 h1:RnEICeDReapbZ5lZEgHvj7E9Q3Eex9toYmaGBsb
 github.com/opencontainers/runc v1.2.8/go.mod h1:cC0YkmZcuvr+rtBZ6T7NBoVbMGNAdLa/21vIElJDOzI=
 github.com/ory/dockertest/v3 v3.12.0 h1:3oV9d0sDzlSQfHtIaB5k6ghUCVMVLpAY8hwrqoCyRCw=
 github.com/ory/dockertest/v3 v3.12.0/go.mod h1:aKNDTva3cp8dwOWwb9cWuX84aH5akkxXRvO7KCwWVjE=
+github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
+github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/stores/stores.go
+++ b/stores/stores.go
@@ -36,7 +36,7 @@ type SopsFile struct {
 	// in the SOPS file by checking for nil. This way we can show the user a
 	// helpful error message indicating that the metadata wasn't found, instead
 	// of showing a cryptic parsing error
-	Metadata *Metadata `yaml:"sops" json:"sops" ini:"sops"`
+	Metadata *Metadata `yaml:"sops" json:"sops" ini:"sops" toml:"sops"`
 }
 
 // Metadata is stored in SOPS encrypted files, and it contains the information necessary to decrypt the file.
@@ -44,83 +44,83 @@ type SopsFile struct {
 // in order to allow the binary format to stay backwards compatible over time, but at the same time allow the internal
 // representation SOPS uses to change over time.
 type Metadata struct {
-	ShamirThreshold           int         `yaml:"shamir_threshold,omitempty" json:"shamir_threshold,omitempty"`
-	KeyGroups                 []keygroup  `yaml:"key_groups,omitempty" json:"key_groups,omitempty"`
-	KMSKeys                   []kmskey    `yaml:"kms,omitempty" json:"kms,omitempty"`
-	GCPKMSKeys                []gcpkmskey `yaml:"gcp_kms,omitempty" json:"gcp_kms,omitempty"`
-	HCKmsKeys                 []hckmskey  `yaml:"hckms,omitempty" json:"hckms,omitempty"`
-	AzureKeyVaultKeys         []azkvkey   `yaml:"azure_kv,omitempty" json:"azure_kv,omitempty"`
-	VaultKeys                 []vaultkey  `yaml:"hc_vault,omitempty" json:"hc_vault,omitempty"`
-	AgeKeys                   []agekey    `yaml:"age,omitempty" json:"age,omitempty"`
-	LastModified              string      `yaml:"lastmodified" json:"lastmodified"`
-	MessageAuthenticationCode string      `yaml:"mac" json:"mac"`
-	PGPKeys                   []pgpkey    `yaml:"pgp,omitempty" json:"pgp,omitempty"`
-	UnencryptedSuffix         string      `yaml:"unencrypted_suffix,omitempty" json:"unencrypted_suffix,omitempty"`
-	EncryptedSuffix           string      `yaml:"encrypted_suffix,omitempty" json:"encrypted_suffix,omitempty"`
-	UnencryptedRegex          string      `yaml:"unencrypted_regex,omitempty" json:"unencrypted_regex,omitempty"`
-	EncryptedRegex            string      `yaml:"encrypted_regex,omitempty" json:"encrypted_regex,omitempty"`
-	UnencryptedCommentRegex   string      `yaml:"unencrypted_comment_regex,omitempty" json:"unencrypted_comment_regex,omitempty"`
-	EncryptedCommentRegex     string      `yaml:"encrypted_comment_regex,omitempty" json:"encrypted_comment_regex,omitempty"`
-	MACOnlyEncrypted          bool        `yaml:"mac_only_encrypted,omitempty" json:"mac_only_encrypted,omitempty"`
-	Version                   string      `yaml:"version" json:"version"`
+	ShamirThreshold           int         `yaml:"shamir_threshold,omitempty" json:"shamir_threshold,omitempty" toml:"shamir_threshold,omitempty"`
+	KeyGroups                 []keygroup  `yaml:"key_groups,omitempty" json:"key_groups,omitempty" toml:"key_groups,omitempty"`
+	KMSKeys                   []kmskey    `yaml:"kms,omitempty" json:"kms,omitempty" toml:"kms,omitempty"`
+	GCPKMSKeys                []gcpkmskey `yaml:"gcp_kms,omitempty" json:"gcp_kms,omitempty" toml:"gcp_kms,omitempty"`
+	HCKmsKeys                 []hckmskey  `yaml:"hckms,omitempty" json:"hckms,omitempty" toml:"hckms,omitempty"`
+	AzureKeyVaultKeys         []azkvkey   `yaml:"azure_kv,omitempty" json:"azure_kv,omitempty" toml:"azure_kv,omitempty"`
+	VaultKeys                 []vaultkey  `yaml:"hc_vault,omitempty" json:"hc_vault,omitempty" toml:"hc_vault,omitempty"`
+	AgeKeys                   []agekey    `yaml:"age,omitempty" json:"age,omitempty" toml:"age,omitempty"`
+	LastModified              string      `yaml:"lastmodified" json:"lastmodified" toml:"lastmodified"`
+	MessageAuthenticationCode string      `yaml:"mac" json:"mac" toml:"mac"`
+	PGPKeys                   []pgpkey    `yaml:"pgp,omitempty" json:"pgp,omitempty" toml:"pgp,omitempty"`
+	UnencryptedSuffix         string      `yaml:"unencrypted_suffix,omitempty" json:"unencrypted_suffix,omitempty" toml:"unencrypted_suffix,omitempty"`
+	EncryptedSuffix           string      `yaml:"encrypted_suffix,omitempty" json:"encrypted_suffix,omitempty" toml:"encrypted_suffix,omitempty"`
+	UnencryptedRegex          string      `yaml:"unencrypted_regex,omitempty" json:"unencrypted_regex,omitempty" toml:"unencrypted_regex,omitempty"`
+	EncryptedRegex            string      `yaml:"encrypted_regex,omitempty" json:"encrypted_regex,omitempty" toml:"encrypted_regex,omitempty"`
+	UnencryptedCommentRegex   string      `yaml:"unencrypted_comment_regex,omitempty" json:"unencrypted_comment_regex,omitempty" toml:"unencrypted_comment_regex,omitempty"`
+	EncryptedCommentRegex     string      `yaml:"encrypted_comment_regex,omitempty" json:"encrypted_comment_regex,omitempty" toml:"encrypted_comment_regex,omitempty"`
+	MACOnlyEncrypted          bool        `yaml:"mac_only_encrypted,omitempty" json:"mac_only_encrypted,omitempty" toml:"mac_only_encrypted,omitempty"`
+	Version                   string      `yaml:"version" json:"version" toml:"version"`
 }
 
 type keygroup struct {
-	PGPKeys           []pgpkey    `yaml:"pgp,omitempty" json:"pgp,omitempty"`
-	KMSKeys           []kmskey    `yaml:"kms,omitempty" json:"kms,omitempty"`
-	GCPKMSKeys        []gcpkmskey `yaml:"gcp_kms,omitempty" json:"gcp_kms,omitempty"`
-	HCKmsKeys         []hckmskey  `yaml:"hckms,omitempty" json:"hckms,omitempty"`
-	AzureKeyVaultKeys []azkvkey   `yaml:"azure_kv,omitempty" json:"azure_kv,omitempty"`
-	VaultKeys         []vaultkey  `yaml:"hc_vault" json:"hc_vault"`
-	AgeKeys           []agekey    `yaml:"age" json:"age"`
+	PGPKeys           []pgpkey    `yaml:"pgp,omitempty" json:"pgp,omitempty" toml:"pgp,omitempty"`
+	KMSKeys           []kmskey    `yaml:"kms,omitempty" json:"kms,omitempty" toml:"kms,omitempty"`
+	GCPKMSKeys        []gcpkmskey `yaml:"gcp_kms,omitempty" json:"gcp_kms,omitempty" toml:"gcp_kms,omitempty"`
+	HCKmsKeys         []hckmskey  `yaml:"hckms,omitempty" json:"hckms,omitempty" toml:"hckms,omitempty"`
+	AzureKeyVaultKeys []azkvkey   `yaml:"azure_kv,omitempty" json:"azure_kv,omitempty" toml:"azure_kv,omitempty"`
+	VaultKeys         []vaultkey  `yaml:"hc_vault" json:"hc_vault" toml:"hc_vault"`
+	AgeKeys           []agekey    `yaml:"age" json:"age" toml:"age"`
 }
 
 type pgpkey struct {
-	CreatedAt        string `yaml:"created_at" json:"created_at"`
-	EncryptedDataKey string `yaml:"enc" json:"enc"`
-	Fingerprint      string `yaml:"fp" json:"fp"`
+	CreatedAt        string `yaml:"created_at" json:"created_at" toml:"created_at"`
+	EncryptedDataKey string `yaml:"enc" json:"enc" toml:"enc"`
+	Fingerprint      string `yaml:"fp" json:"fp" toml:"fp"`
 }
 
 type kmskey struct {
-	Arn              string             `yaml:"arn" json:"arn"`
-	Role             string             `yaml:"role,omitempty" json:"role,omitempty"`
-	Context          map[string]*string `yaml:"context,omitempty" json:"context,omitempty"`
-	CreatedAt        string             `yaml:"created_at" json:"created_at"`
-	EncryptedDataKey string             `yaml:"enc" json:"enc"`
-	AwsProfile       string             `yaml:"aws_profile" json:"aws_profile"`
+	Arn              string             `yaml:"arn" json:"arn" toml:"arn"`
+	Role             string             `yaml:"role,omitempty" json:"role,omitempty" toml:"role,omitempty"`
+	Context          map[string]*string `yaml:"context,omitempty" json:"context,omitempty" toml:"context,omitempty"`
+	CreatedAt        string             `yaml:"created_at" json:"created_at" toml:"created_at"`
+	EncryptedDataKey string             `yaml:"enc" json:"enc" toml:"enc"`
+	AwsProfile       string             `yaml:"aws_profile" json:"aws_profile" toml:"aws_profile"`
 }
 
 type gcpkmskey struct {
-	ResourceID       string `yaml:"resource_id" json:"resource_id"`
-	CreatedAt        string `yaml:"created_at" json:"created_at"`
-	EncryptedDataKey string `yaml:"enc" json:"enc"`
+	ResourceID       string `yaml:"resource_id" json:"resource_id" toml:"resource_id"`
+	CreatedAt        string `yaml:"created_at" json:"created_at" toml:"created_at"`
+	EncryptedDataKey string `yaml:"enc" json:"enc" toml:"enc"`
 }
 
 type vaultkey struct {
-	VaultAddress     string `yaml:"vault_address" json:"vault_address"`
-	EnginePath       string `yaml:"engine_path" json:"engine_path"`
-	KeyName          string `yaml:"key_name" json:"key_name"`
-	CreatedAt        string `yaml:"created_at" json:"created_at"`
-	EncryptedDataKey string `yaml:"enc" json:"enc"`
+	VaultAddress     string `yaml:"vault_address" json:"vault_address" toml:"vault_address"`
+	EnginePath       string `yaml:"engine_path" json:"engine_path" toml:"engine_path"`
+	KeyName          string `yaml:"key_name" json:"key_name" toml:"key_name"`
+	CreatedAt        string `yaml:"created_at" json:"created_at" toml:"created_at"`
+	EncryptedDataKey string `yaml:"enc" json:"enc" toml:"enc"`
 }
 
 type azkvkey struct {
-	VaultURL         string `yaml:"vault_url" json:"vault_url"`
-	Name             string `yaml:"name" json:"name"`
-	Version          string `yaml:"version" json:"version"`
-	CreatedAt        string `yaml:"created_at" json:"created_at"`
-	EncryptedDataKey string `yaml:"enc" json:"enc"`
+	VaultURL         string `yaml:"vault_url" json:"vault_url" toml:"vault_url"`
+	Name             string `yaml:"name" json:"name" toml:"name"`
+	Version          string `yaml:"version" json:"version" toml:"version"`
+	CreatedAt        string `yaml:"created_at" json:"created_at" toml:"created_at"`
+	EncryptedDataKey string `yaml:"enc" json:"enc" toml:"enc"`
 }
 
 type agekey struct {
-	Recipient        string `yaml:"recipient" json:"recipient"`
-	EncryptedDataKey string `yaml:"enc" json:"enc"`
+	Recipient        string `yaml:"recipient" json:"recipient" toml:"recipient"`
+	EncryptedDataKey string `yaml:"enc" json:"enc" toml:"enc"`
 }
 
 type hckmskey struct {
-	KeyID            string `yaml:"key_id" json:"key_id"`
-	CreatedAt        string `yaml:"created_at" json:"created_at"`
-	EncryptedDataKey string `yaml:"enc" json:"enc"`
+	KeyID            string `yaml:"key_id" json:"key_id" toml:"key_id"`
+	CreatedAt        string `yaml:"created_at" json:"created_at" toml:"created_at"`
+	EncryptedDataKey string `yaml:"enc" json:"enc" toml:"enc"`
 }
 
 // MetadataFromInternal converts an internal SOPS metadata representation to a representation appropriate for storage

--- a/stores/toml/store.go
+++ b/stores/toml/store.go
@@ -1,0 +1,280 @@
+package toml //import "github.com/getsops/sops/v3/stores/toml"
+
+import (
+	"errors"
+	"fmt"
+	"github.com/getsops/sops/v3"
+	"github.com/getsops/sops/v3/config"
+	"github.com/getsops/sops/v3/stores"
+	"sort"
+
+	"github.com/pelletier/go-toml"
+)
+
+// Store handles storage of TOML data.
+type Store struct {
+	config *config.TOMLStoreConfig
+}
+
+func NewStore(c *config.TOMLStoreConfig) *Store {
+	return &Store{config: c}
+}
+
+func (store *Store) Name() string {
+	return "toml"
+}
+
+// positionKey is necessary to keep the order when we append in branches.
+type positionKey struct {
+	position int
+	key      string
+}
+
+type byPosition []positionKey
+
+func (b byPosition) Less(i, j int) bool { return b[i].position < b[j].position }
+func (b byPosition) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
+func (b byPosition) Len() int           { return len(b) }
+
+var errUnexpectedValue = errors.New("unexpected value")
+
+func tomlTreeToTreeBranch(tr *toml.Tree) (sops.TreeBranch, error) {
+	treeItems := make(map[string]sops.TreeItem)
+	pks := []positionKey{}
+
+	for k, v := range tr.Values() {
+		switch node := v.(type) {
+		case []*toml.Tree:
+			maxPosition := 0
+
+			var treeBranches []interface{}
+
+			for _, item := range node {
+				if item.Position().Line > maxPosition {
+					maxPosition = item.Position().Line
+				}
+
+				branch, errT := tomlTreeToTreeBranch(item)
+				if errT != nil {
+					return nil, fmt.Errorf("tomlTreeToTreeBranch: %w - %v, %s", errUnexpectedValue, v, k)
+				}
+
+				treeBranches = append(treeBranches, branch)
+			}
+
+			pks = append(pks, positionKey{position: maxPosition, key: k})
+			treeItems[k] = sops.TreeItem{
+				Key:   k,
+				Value: treeBranches,
+			}
+		case *toml.Tree:
+			pks = append(pks, positionKey{position: node.Position().Line, key: k})
+
+			branch, errT := tomlTreeToTreeBranch(node)
+			if errT != nil {
+				return nil, fmt.Errorf("tomlTreeToTreeBranch: %w - %v, %s", errUnexpectedValue, v, k)
+			}
+
+			treeItems[k] = sops.TreeItem{
+				Key:   k,
+				Value: branch,
+			}
+		case *toml.PubTOMLValue:
+			pks = append(pks, positionKey{position: node.Position().Line, key: k})
+			treeItems[k] = sops.TreeItem{
+				Key:   k,
+				Value: node.Value(),
+			}
+		default:
+			return nil, fmt.Errorf("tomlTreeToTreeBranch: %w - %v, %s", errUnexpectedValue, v, k)
+		}
+	}
+
+	sort.Sort(byPosition(pks))
+
+	var br sops.TreeBranch
+	for _, pk := range pks {
+		br = append(br, treeItems[pk.key])
+	}
+
+	return br, nil
+}
+
+func treeBranchToTOMLTree(stree sops.TreeBranch) (*toml.Tree, error) {
+	ttree := &toml.PubTree{}
+	values := make(map[string]interface{})
+
+	for _, treeItem := range stree {
+		var errT error
+
+		values[treeItem.Key.(string)], errT = treeItemValueToTOML(treeItem.Value)
+		if errT != nil {
+			return nil, errT
+		}
+	}
+
+	ttree.SetValues(values)
+
+	return ttree, nil
+}
+
+func treeItemValueToTOML(treeItemValue interface{}) (interface{}, error) {
+	switch treeItemValueTyped := treeItemValue.(type) {
+	case sops.TreeBranch:
+		return treeBranchToTOMLTree(treeItemValueTyped)
+
+	case []interface{}:
+		switch treeItemValueTyped[0].(type) {
+		case sops.TreeBranch:
+			var array []*toml.Tree
+
+			for _, itm := range treeItemValueTyped {
+				tb := itm.(sops.TreeBranch)
+
+				tr, errT := treeBranchToTOMLTree(tb)
+				if errT != nil {
+					return nil, errT
+				}
+
+				array = append(array, tr)
+			}
+
+			return array, nil
+		default:
+			val := &toml.PubTOMLValue{}
+			val.SetValue(treeItemValueTyped)
+
+			return val, nil
+		}
+
+	default:
+		val := &toml.PubTOMLValue{}
+		val.SetValue(treeItemValueTyped)
+
+		return val, nil
+	}
+}
+
+// LoadEncryptedFile loads the contents of an encrypted toml file onto a
+// sops.Tree runtime object.
+func (s *Store) LoadEncryptedFile(in []byte) (sops.Tree, error) {
+	data, err := toml.LoadBytes(in)
+	if err != nil {
+		return sops.Tree{}, fmt.Errorf("error unmarshalling input toml: %w", err)
+	}
+
+	// Because we don't know what fields the input file will have, we have to
+	// load the file in two steps.
+	// First, we load the file's metadata, the structure of which is known.
+	metadataHolder := stores.SopsFile{}
+	if err := data.Unmarshal(&metadataHolder); err != nil {
+		return sops.Tree{}, fmt.Errorf("error unmarshalling input toml: %w", err)
+	}
+
+	if metadataHolder.Metadata == nil {
+		return sops.Tree{}, sops.MetadataNotFound
+	}
+
+	metadata, err := metadataHolder.Metadata.ToInternal()
+	if err != nil {
+		return sops.Tree{}, fmt.Errorf("error unmarshalling input toml: %w", err)
+	}
+
+	branch, errT := tomlTreeToTreeBranch(data)
+	if errT != nil {
+		return sops.Tree{}, fmt.Errorf("error transforming toml Tree: %w", err)
+	}
+
+	return sops.Tree{
+		Branches: sops.TreeBranches{branch},
+		Metadata: metadata,
+	}, nil
+}
+
+// LoadPlainFile loads the contents of a plaintext toml file onto a
+// sops.Tree runtime object.
+func (s *Store) LoadPlainFile(in []byte) (sops.TreeBranches, error) {
+	tomlTree, err := toml.LoadBytes(in)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling input toml: %w", err)
+	}
+
+	branch, errT := tomlTreeToTreeBranch(tomlTree)
+	if errT != nil {
+		return nil, fmt.Errorf("error transforming toml Tree: %w", err)
+	}
+
+	return sops.TreeBranches{branch}, nil
+}
+
+var errTOMLUniqueDocument = errors.New("toml can only contain 1 document")
+
+// EmitEncryptedFile returns the encrypted bytes of the toml file corresponding to a
+// sops.Tree runtime object.
+func (s *Store) EmitEncryptedFile(in sops.Tree) ([]byte, error) {
+	if len(in.Branches) != 1 {
+		return nil, errTOMLUniqueDocument
+	}
+
+	tomlTree, err := treeBranchToTOMLTree(in.Branches[0])
+	if err != nil {
+		return nil, errTOMLUniqueDocument
+	}
+
+	values := tomlTree.Values()
+	values["sops"] = stores.MetadataFromInternal(in.Metadata)
+	tomlTree.SetValues(values)
+
+	return []byte(tomlTree.String()), nil
+}
+
+// EmitPlainFile returns the plaintext bytes of the toml file corresponding to a
+// sops.TreeBranches runtime object.
+func (s *Store) EmitPlainFile(branches sops.TreeBranches) ([]byte, error) {
+	if len(branches) != 1 {
+		return nil, errTOMLUniqueDocument
+	}
+
+	tomlTree, err := treeBranchToTOMLTree(branches[0])
+	if err != nil {
+		return nil, fmt.Errorf("emit plain file: %w", err)
+	}
+
+	return tomlTree.Marshal()
+}
+
+// EmitValue returns bytes corresponding to a single encoded value
+// in a generic interface{} object.
+func (s *Store) EmitValue(v interface{}) ([]byte, error) {
+	switch v := v.(type) {
+	case sops.TreeBranch:
+		tomlTree, err := treeBranchToTOMLTree(v)
+		if err != nil {
+			return nil, fmt.Errorf("emit plain file: %w", err)
+		}
+
+		return tomlTree.Marshal()
+	default:
+		str, err := toml.ValueStringRepresentation(v, "", "", toml.OrderPreserve, false)
+		if err != nil {
+			return nil, fmt.Errorf("emit plain file: %w", err)
+		}
+		return []byte(str), nil
+	}
+
+}
+
+// EmitExample returns the bytes corresponding to an example complex tree.
+func (s *Store) EmitExample() []byte {
+	bytes, err := s.EmitPlainFile(stores.ExampleComplexTree.Branches)
+	if err != nil {
+		panic(err)
+	}
+
+	return bytes
+}
+
+// HasSopsTopLevelKey checks whether a top-level "sops" key exists.
+func (store *Store) HasSopsTopLevelKey(branch sops.TreeBranch) bool {
+	return stores.HasSopsTopLevelKey(branch)
+}

--- a/stores/toml/store_test.go
+++ b/stores/toml/store_test.go
@@ -1,0 +1,234 @@
+package toml
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/getsops/sops/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+func testPlain() []byte {
+	return []byte(
+		`# 0 comment
+0 = 0
+1 = 1 # 1 comment
+
+[2]
+  21 = [21.1, 21.2] # 21 comment
+  22 = 22
+
+[2.1]
+  211 = 211
+
+[[2.1.1]]
+  2111 = 2111
+
+[[2.1.1]]
+  2112 = 2112
+
+[[3]]
+  31 = "thirty one"
+
+[[3]]
+  32 = "thirty two"
+
+# 4 comment
+[4]
+  # 41 comment
+  41 = 41
+`)
+}
+
+func testPlainNoComment() []byte {
+	return []byte(
+		`0 = 0
+1 = 1
+
+[2]
+  21 = [21.1, 21.2]
+  22 = 22
+
+  [2.1]
+    211 = 211
+
+    [[2.1.1]]
+      2111 = 2111
+
+    [[2.1.1]]
+      2112 = 2112
+
+[[3]]
+  31 = "thirty one"
+
+[[3]]
+  32 = "thirty two"
+
+[4]
+  41 = 41
+`)
+}
+
+func testTreeBranches() sops.TreeBranches {
+	return sops.TreeBranches{
+		sops.TreeBranch{
+			// NOT IMPL on go-toml yet
+			// sops.TreeItem{
+			// 	Key: sops.Comment{
+			// 		Value: " 0 comment",
+			// 	},
+			// 	Value: interface{}(nil),
+			// },
+			sops.TreeItem{
+				Key:   "0",
+				Value: int64(0),
+			},
+			sops.TreeItem{
+				Key:   "1",
+				Value: int64(1),
+			},
+			// NOT IMPL on go-toml yet
+			// sops.TreeItem{
+			// 	Key: sops.Comment{
+			// 		Value: " 1 comment",
+			// 	},
+			// 	Value: interface{}(nil),
+			// },
+			sops.TreeItem{
+				Key: "2",
+				Value: sops.TreeBranch{
+					// NOT IMPL on go-toml yet
+					// sops.TreeItem{
+					// 	Key: sops.Comment{
+					// 		Value: " 21 comment",
+					// 	},
+					// 	Value: interface{}(nil),
+					// },
+					sops.TreeItem{
+						Key: "21",
+						Value: []interface{}{
+							21.1,
+							21.2,
+						},
+					},
+					sops.TreeItem{
+						Key:   "22",
+						Value: int64(22),
+					},
+					sops.TreeItem{
+						Key: "1",
+						Value: sops.TreeBranch{
+							sops.TreeItem{
+								Key:   "211",
+								Value: int64(211),
+							},
+							sops.TreeItem{
+								Key: "1",
+								Value: []interface{}{
+									sops.TreeBranch{
+										sops.TreeItem{
+											Key:   "2111",
+											Value: int64(2111),
+										},
+									},
+									sops.TreeBranch{
+										sops.TreeItem{
+											Key:   "2112",
+											Value: int64(2112),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			sops.TreeItem{
+				Key: "3",
+				Value: []interface{}{
+					sops.TreeBranch{
+						sops.TreeItem{
+							Key:   "31",
+							Value: "thirty one",
+						},
+					},
+					sops.TreeBranch{
+						sops.TreeItem{
+							Key:   "32",
+							Value: "thirty two",
+						},
+						// NOT IMPL on go-toml yet
+						// sops.TreeItem{
+						// 	Key: sops.Comment{
+						// 		Value: " 4 comment",
+						// 	},
+						// 	Value: interface{}(nil),
+						// },
+					},
+				},
+			},
+			// NOT IMPL on go-toml yet
+			// sops.TreeItem{
+			// 	Key: sops.Comment{
+			// 		Value: " 41 comment",
+			// 	},
+			// 	Value: interface{}(nil),
+			// },
+			sops.TreeItem{
+				Key: "4",
+				Value: sops.TreeBranch{
+					sops.TreeItem{
+						Key:   "41",
+						Value: int64(41),
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestLoadPlainFile(t *testing.T) {
+	t.Parallel()
+
+	actualBranches, err := (&Store{}).LoadPlainFile(testPlain())
+	if err != nil {
+		t.Errorf("expected no error, got: %v", err)
+
+		return
+	}
+
+	expectedBranches := testTreeBranches()
+
+	if !reflect.DeepEqual(expectedBranches, actualBranches) {
+		t.Errorf("expected\n%#v\ngot\n%#v", expectedBranches, actualBranches)
+
+		return
+	}
+}
+
+func TestEmitPlainFile(t *testing.T) {
+	t.Parallel()
+
+	branches := testTreeBranches()
+
+	bytes, err := (&Store{}).EmitPlainFile(branches)
+	if err != nil {
+		t.Errorf("expected no error, got: %v", err)
+
+		return
+	}
+
+	if !reflect.DeepEqual(testPlainNoComment(), bytes) {
+		t.Errorf("expected\n\n-%s-\n\ngot\n\n-%s-", testPlainNoComment(), bytes)
+
+		return
+	}
+}
+
+func TestEmitValueString(t *testing.T) {
+	t.Parallel()
+
+	bytes, err := (&Store{}).EmitValue("hello")
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("\"hello\""), bytes)
+}


### PR DESCRIPTION
Fixes #369. Supersedes #812 (that in turn superseded #533). Hopefully, the third time's the charm.

Uses `github.com/pelletier/go-toml/v2`. It discards comments.