### PR TITLE
Support hybrid (post-quantum) age identities

### DIFF
--- a/age/keysource.go
+++ b/age/keysource.go
@@ -427,6 +427,13 @@ func (key *MasterKey) loadIdentities() (ParsedIdentities, []string, errSet) {
 // key or a public ssh key.
 func parseRecipient(recipient string) (age.Recipient, error) {
 	switch {
+	case strings.HasPrefix(recipient, "age1pq1"):
+		parsedRecipient, err := age.ParseHybridRecipient(recipient)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse input as Bech32-encoded age public key: %w", err)
+		}
+
+		return parsedRecipient, nil
 	case strings.HasPrefix(recipient, "age1") && strings.Count(recipient, "1") > 1:
 		parsedRecipient, err := plugin.NewRecipient(recipient, pluginTerminalUI)
 		if err != nil {
@@ -481,6 +488,8 @@ func parseIdentity(s string) (age.Identity, error) {
 	switch {
 	case strings.HasPrefix(s, "AGE-PLUGIN-"):
 		return plugin.NewIdentity(s, pluginTerminalUI)
+	case strings.HasPrefix(s, "AGE-SECRET-KEY-PQ-1"):
+		return age.ParseHybridIdentity(s)
 	case strings.HasPrefix(s, "AGE-SECRET-KEY-1"):
 		return age.ParseX25519Identity(s)
 	default:

--- a/age/keysource_test.go
+++ b/age/keysource_test.go
@@ -16,6 +16,8 @@ const (
 	mockRecipient string = "age1lzd99uklcjnc0e7d860axevet2cz99ce9pq6tzuzd05l5nr28ams36nvun"
 	// mockIdentity is a mock age identity.
 	mockIdentity string = "AGE-SECRET-KEY-1G0Q5K9TV4REQ3ZSQRMTMG8NSWQGYT0T7TZ33RAZEE0GZYVZN0APSU24RK7"
+	// mockHybridIdentity is a mock post-quantum age identity using a hybrid ML-KEM-768 KEM.
+	mockHybridIdentity string = "AGE-SECRET-KEY-PQ-1JPDDEMSK6G9MG0VNJRSA0QKZ05CF4H6TK50YZGDKZKTRGC5Z7KEQUDUPG6"
 	// mockOtherIdentity is another mock age identity.
 	mockOtherIdentity string = "AGE-SECRET-KEY-1432K5YRNSC44GC4986NXMX6GVZ52WTMT9C79CLUVWYY4DKDHD5JSNDP4MC"
 	// mockEncryptedKey equals to mockEncryptedKeyPlain when decrypted with mockIdentity.
@@ -147,11 +149,11 @@ func TestMasterKeyFromRecipient(t *testing.T) {
 
 func TestParsedIdentities_Import(t *testing.T) {
 	i := make(ParsedIdentities, 0)
-	assert.NoError(t, i.Import(mockIdentity, mockOtherIdentity))
-	assert.Len(t, i, 2)
+	assert.NoError(t, i.Import(mockIdentity, mockOtherIdentity, mockHybridIdentity))
+	assert.Len(t, i, 3)
 
 	assert.Error(t, i.Import("invalid"))
-	assert.Len(t, i, 2)
+	assert.Len(t, i, 3)
 }
 
 func TestParsedIdentities_ApplyToMasterKey(t *testing.T) {


### PR DESCRIPTION
Making use of the [recently upgraded](https://github.com/getsops/sops/pull/2029) age 1.3.1.

I'm not too familiar with the codebase (or age itself), so I only added one test. If you think more are needed, I can try add more if you tell me which ones are required.
