### PR TITLE
Adjust role split string to not hardcode 'aws' partition of AWS

### DIFF
--- a/kms/keysource.go
+++ b/kms/keysource.go
@@ -109,7 +109,10 @@ func NewMasterKeyFromArn(arn string, context map[string]*string, awsProfile stri
 	key := &MasterKey{}
 	arn = strings.Replace(arn, " ", "", -1)
 	key.Arn = arn
-	roleIndex := strings.Index(arn, "+arn:aws:iam::")
+	// While ARN paths can contain '+', they cannot contain ':'.
+	// Thus '+arn:' must be separating two ARNs that have been concatenated with '+'.
+	// (While KMS ARN paths currently do not contain '+', I think it's better to be safe than sorry.)
+	roleIndex := strings.Index(arn, "+arn:")
 	if roleIndex > 0 {
 		// Overwrite ARN
 		key.Arn = arn[:roleIndex]

--- a/kms/keysource_test.go
+++ b/kms/keysource_test.go
@@ -165,6 +165,12 @@ func TestNewMasterKeyFromArn(t *testing.T) {
 		assert.Equal(t, "arn:aws:kms:us-west-2:927034868273:key/fe86dd69-4132-404c-ab86-4269956b4500", key.Arn)
 		assert.Equal(t, "arn:aws:iam::927034868273:role/sops-dev-xyz", key.Role)
 	})
+
+	t.Run("arn with role in another partition", func(t *testing.T) {
+		key := NewMasterKeyFromArn("arn:aws-foobar:kms:bazbam:927034868273:key/fe86dd69-4132-404c-ab86-4269956b4500+arn:aws-foobar:iam::927034868273:role/sops-dev-xyz", nil, "")
+		assert.Equal(t, "arn:aws-foobar:kms:bazbam:927034868273:key/fe86dd69-4132-404c-ab86-4269956b4500", key.Arn)
+		assert.Equal(t, "arn:aws-foobar:iam::927034868273:role/sops-dev-xyz", key.Role)
+	})
 }
 
 func TestMasterKeysFromArnString(t *testing.T) {


### PR DESCRIPTION
This also makes it possible to use AWS's new ECS (European Sovereign Cloud), which uses the partition `aws-eusc` according to https://aws.amazon.com/blogs/aws/opening-the-aws-european-sovereign-cloud/.

Reference on ARNs: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html

Fixes #805.
Closes #806.
