### PR TITLE
test: Unset user GNUPGHOME env var for gnuPGHome

### DIFF
--- a/pgp/keysource_test.go
+++ b/pgp/keysource_test.go
@@ -682,6 +682,7 @@ func Test_gpgBinary(t *testing.T) {
 }
 
 func Test_gnuPGHome(t *testing.T) {
+	t.Setenv("GNUPGHOME", "")
 	usr, err := user.Current()
 	if err == nil {
 		assert.Equal(t, filepath.Join(usr.HomeDir, ".gnupg"), gnuPGHome(""))


### PR DESCRIPTION
Closes #2051 by unsetting the user-set `GNUPGHOME` var. Cannot be unset in Makefile without breaking later usage of actual gpg config.