### PR TITLE
feat: add SOPS_AGE_SSH_PRIVATE_KEY_CMD

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -250,9 +250,16 @@ identity will be tried in sequence until one is able to decrypt the data.
 
 Encrypting with SSH keys via age is also supported by SOPS. You can use SSH public keys
 ("ssh-ed25519 AAAA...", "ssh-rsa AAAA...") as age recipients when encrypting a file.
-When decrypting a file, SOPS will look for ``~/.ssh/id_ed25519`` and falls back to
-``~/.ssh/id_rsa``. You can specify the location of the private key manually by setting
-the environment variable **SOPS_AGE_SSH_PRIVATE_KEY_FILE**.
+
+When decrypting a file, SOPS will attempt to source the SSH private key as follows:
+
+- From the path specified in environment variable **SOPS_AGE_SSH_PRIVATE_KEY_FILE**.
+- From the output of the command specified in environment variable **SOPS_AGE_SSH_PRIVATE_KEY_CMD**.
+
+   .. note:: The output of this command must provide a key that is not password protected.
+
+- From ``~/.ssh/id_ed25519``.
+- From ``~/.ssh/id_rsa``.
 
 Note that only ``ssh-rsa`` and ``ssh-ed25519`` are supported.
 

--- a/age/keysource.go
+++ b/age/keysource.go
@@ -17,6 +17,7 @@ import (
 	"filippo.io/age/armor"
 	"filippo.io/age/plugin"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh"
 
 	"github.com/getsops/sops/v3/logging"
 	"github.com/google/shlex"
@@ -36,6 +37,9 @@ const (
 	// set in SopsAgeKeyCmdEnv and contains the Bech32-encoded age public key
 	// for which the private key should be returned.
 	SopsAgeRecipientEnv = "SOPS_AGE_RECIPIENT"
+	// SopsAgeSshPrivateKeyCmdEnv can be set as an environment variable with a command
+	// to execute that returns the private SSH key.
+	SopsAgeSshPrivateKeyCmdEnv = "SOPS_AGE_SSH_PRIVATE_KEY_CMD"
 	// SopsAgeSshPrivateKeyFileEnv can be set as an environment variable pointing to
 	// a private SSH key file.
 	SopsAgeSshPrivateKeyFileEnv = "SOPS_AGE_SSH_PRIVATE_KEY_FILE"
@@ -290,11 +294,35 @@ func (key *MasterKey) TypeToIdentifier() string {
 	return KeyTypeIdentifier
 }
 
-// loadAgeSSHIdentity attempts to load the age SSH identity based on an SSH
-// private key from the SopsAgeSshPrivateKeyFileEnv environment variable. If the
-// environment variable is not present, it will fall back to `~/.ssh/id_ed25519`
-// or `~/.ssh/id_rsa`. If no age SSH identity is found, it will return nil.
-func loadAgeSSHIdentities() ([]age.Identity, []string, errSet) {
+// getOutputFromCmd executes a shell command provided in param 'cmdString',
+// optionally adding env vars provided in param 'envVars',
+// and returns the command's output and error
+func getOutputFromCmd(cmdString string, envVars []string) ([]byte, error) {
+	var out []byte
+
+	args, err := shlex.Split(cmdString)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse command %s: %w", cmdString, err)
+	}
+	cmd := exec.Command(args[0], args[1:]...)
+	if envVars != nil {
+		cmd.Env = append(os.Environ(), envVars[0:]...)
+	}
+	out, err = cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute command %s: %w", cmdString, err)
+	}
+
+	return out, nil
+}
+
+// loadAgeSSHIdentity attempts to load age SSH identities in this order:
+// 1. An SSH private key from the SopsAgeSshPrivateKeyFileEnv environment variable.
+// 2. An SSH private key returned by executing the command from the
+// SopsAgeSshPrivateKeyCmdEnv environment variable
+// 3. `~/.ssh/id_ed25519` or `~/.ssh/id_rsa`.
+// If no age SSH identity is found, it will return nil.
+func (key *MasterKey) loadAgeSSHIdentities() ([]age.Identity, []string, errSet) {
 	var identities []age.Identity
 	var unusedLocations []string
 	var errs errSet
@@ -309,6 +337,23 @@ func loadAgeSSHIdentities() ([]age.Identity, []string, errSet) {
 		}
 	} else {
 		unusedLocations = append(unusedLocations, SopsAgeSshPrivateKeyFileEnv)
+	}
+
+	sshKeyCmd, ok := os.LookupEnv(SopsAgeSshPrivateKeyCmdEnv)
+	if ok {
+		out, err := getOutputFromCmd(sshKeyCmd, []string{fmt.Sprintf("%s=%s", SopsAgeRecipientEnv, key.Recipient)})
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			identity, err := parseSSHIdentityFromPrivateKeyCmdOutput(out)
+			if err != nil {
+				errs = append(errs, err)
+			} else {
+				identities = append(identities, identity)
+			}
+		}
+	} else {
+		unusedLocations = append(unusedLocations, SopsAgeSshPrivateKeyCmdEnv)
 	}
 
 	userHomeDir, err := os.UserHomeDir()
@@ -359,7 +404,7 @@ func getUserConfigDir() (string, error) {
 // SopsAgeSshPrivateKeyFileEnv, SopsAgeKeyUserConfigPath). It will load all
 // found references, and expects at least one configuration to be present.
 func (key *MasterKey) loadIdentities() (ParsedIdentities, []string, errSet) {
-	identities, unusedLocations, errs := loadAgeSSHIdentities()
+	identities, unusedLocations, errs := key.loadAgeSSHIdentities()
 
 	var readers = make(map[string]io.Reader, 0)
 
@@ -382,18 +427,11 @@ func (key *MasterKey) loadIdentities() (ParsedIdentities, []string, errSet) {
 	}
 
 	if ageKeyCmd, ok := os.LookupEnv(SopsAgeKeyCmdEnv); ok {
-		args, err := shlex.Split(ageKeyCmd)
+		out, err := getOutputFromCmd(ageKeyCmd, []string{fmt.Sprintf("%s=%s", SopsAgeRecipientEnv, key.Recipient)})
 		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to parse command %s from %s: %w", ageKeyCmd, SopsAgeKeyCmdEnv, err))
+			errs = append(errs, err)
 		} else {
-			cmd := exec.Command(args[0], args[1:]...)
-			cmd.Env = append(os.Environ(), fmt.Sprintf("%s=%s", SopsAgeRecipientEnv, key.Recipient))
-			out, err := cmd.Output()
-			if err != nil {
-				errs = append(errs, fmt.Errorf("failed to execute command %s from %s: %w", ageKeyCmd, SopsAgeKeyCmdEnv, err))
-			} else {
-				readers[SopsAgeKeyCmdEnv] = bytes.NewReader(out)
-			}
+			readers[SopsAgeKeyCmdEnv] = bytes.NewReader(out)
 		}
 	} else {
 		unusedLocations = append(unusedLocations, SopsAgeKeyCmdEnv)
@@ -501,4 +539,17 @@ func parseIdentity(s string) (age.Identity, error) {
 	default:
 		return nil, fmt.Errorf("unknown identity type")
 	}
+}
+
+// parseSSHIdentityFromPrivateKeyCmdOutput returns an age.Identity from the given
+// private key. Note that encrypted private keys are not supported.
+func parseSSHIdentityFromPrivateKeyCmdOutput(key []byte) (age.Identity, error) {
+	id, err := agessh.ParseIdentity(key)
+	if sshErr, ok := err.(*ssh.PassphraseMissingError); ok {
+		return nil, fmt.Errorf("the SSH key returned by running SOPS_AGE_SSH_PRIVATE_KEY_CMD is password protected, which is unsupported. (%q)", sshErr)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("malformed SSH identity returned by running SOPS_AGE_SSH_PRIVATE_KEY_CMD: %q", err)
+	}
+	return id, nil
 }

--- a/age/keysource_test.go
+++ b/age/keysource_test.go
@@ -374,7 +374,7 @@ func TestMasterKey_loadIdentities(t *testing.T) {
 		got, unusedLocations, errs := key.loadIdentities()
 		assert.Len(t, errs, 0)
 		assert.Len(t, got, 1)
-		assert.Len(t, unusedLocations, 5)
+		assert.Len(t, unusedLocations, 6)
 	})
 
 	t.Run(SopsAgeKeyEnv+" multiple", func(t *testing.T) {
@@ -388,7 +388,7 @@ func TestMasterKey_loadIdentities(t *testing.T) {
 		got, unusedLocations, errs := key.loadIdentities()
 		assert.Len(t, errs, 0)
 		assert.Len(t, got, 2)
-		assert.Len(t, unusedLocations, 5)
+		assert.Len(t, unusedLocations, 6)
 	})
 
 	t.Run(SopsAgeKeyFileEnv, func(t *testing.T) {
@@ -405,7 +405,7 @@ func TestMasterKey_loadIdentities(t *testing.T) {
 		got, unusedLocations, errs := key.loadIdentities()
 		assert.Len(t, errs, 0)
 		assert.Len(t, got, 1)
-		assert.Len(t, unusedLocations, 5)
+		assert.Len(t, unusedLocations, 6)
 	})
 
 	t.Run(SopsAgeKeyUserConfigPath, func(t *testing.T) {
@@ -424,7 +424,7 @@ func TestMasterKey_loadIdentities(t *testing.T) {
 		got, unusedLocations, errs := (&MasterKey{}).loadIdentities()
 		assert.Len(t, errs, 0)
 		assert.Len(t, got, 1)
-		assert.Len(t, unusedLocations, 6)
+		assert.Len(t, unusedLocations, 7)
 	})
 
 	t.Run(SopsAgeSshPrivateKeyFileEnv, func(t *testing.T) {
@@ -444,7 +444,7 @@ func TestMasterKey_loadIdentities(t *testing.T) {
 		got, unusedLocations, errs := key.loadIdentities()
 		assert.Len(t, errs, 0)
 		assert.Len(t, got, 1)
-		assert.Len(t, unusedLocations, 5)
+		assert.Len(t, unusedLocations, 6)
 	})
 
 	t.Run("no identity", func(t *testing.T) {
@@ -454,7 +454,7 @@ func TestMasterKey_loadIdentities(t *testing.T) {
 		got, unusedLocations, errs := (&MasterKey{}).loadIdentities()
 		assert.Len(t, errs, 0)
 		assert.Nil(t, got)
-		assert.Len(t, unusedLocations, 7)
+		assert.Len(t, unusedLocations, 8)
 	})
 
 	t.Run("multiple identities", func(t *testing.T) {
@@ -477,7 +477,7 @@ func TestMasterKey_loadIdentities(t *testing.T) {
 		got, unusedLocations, errs := (&MasterKey{}).loadIdentities()
 		assert.Len(t, errs, 0)
 		assert.Len(t, got, 2)
-		assert.Len(t, unusedLocations, 5)
+		assert.Len(t, unusedLocations, 6)
 	})
 
 	t.Run("parsing error", func(t *testing.T) {
@@ -493,7 +493,37 @@ func TestMasterKey_loadIdentities(t *testing.T) {
 		assert.Error(t, errs[0])
 		assert.ErrorContains(t, errs[0], fmt.Sprintf("failed to parse '%s' age identities", SopsAgeKeyEnv))
 		assert.Nil(t, got)
-		assert.Len(t, unusedLocations, 5)
+		assert.Len(t, unusedLocations, 6)
+	})
+
+	t.Run(SopsAgeSshPrivateKeyCmdEnv, func(t *testing.T) {
+		tmpDir := t.TempDir()
+		// Overwrite to ensure local config is not picked up by tests
+		overwriteUserConfigDir(t, tmpDir)
+
+		t.Setenv(SopsAgeSshPrivateKeyCmdEnv, "echo '"+mockSshIdentity+"'")
+
+		key := &MasterKey{}
+		got, unusedLocations, errs := key.loadIdentities()
+		assert.Len(t, errs, 0)
+		assert.Len(t, got, 1)
+		assert.Len(t, unusedLocations, 6)
+	})
+
+	t.Run("cmd error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		// Overwrite to ensure local config is not picked up by tests
+		overwriteUserConfigDir(t, tmpDir)
+
+		t.Setenv(SopsAgeSshPrivateKeyCmdEnv, "meow")
+
+		key := &MasterKey{}
+		got, unusedLocations, errs := key.loadIdentities()
+		assert.Len(t, errs, 1)
+		assert.Error(t, errs[0])
+		assert.ErrorContains(t, errs[0], "failed to execute command meow")
+		assert.Nil(t, got)
+		assert.Len(t, unusedLocations, 7)
 	})
 
 	t.Run(SopsAgeKeyCmdEnv, func(t *testing.T) {
@@ -507,7 +537,7 @@ func TestMasterKey_loadIdentities(t *testing.T) {
 		got, unusedLocations, errs := key.loadIdentities()
 		assert.Len(t, errs, 0)
 		assert.Len(t, got, 1)
-		assert.Len(t, unusedLocations, 5)
+		assert.Len(t, unusedLocations, 6)
 	})
 
 	t.Run(SopsAgeRecipientEnv, func(t *testing.T) {
@@ -521,13 +551,13 @@ func TestMasterKey_loadIdentities(t *testing.T) {
 		got, unusedLocations, errs := key.loadIdentities()
 		assert.Len(t, errs, 0)
 		assert.Len(t, got, 1)
-		assert.Len(t, unusedLocations, 5)
+		assert.Len(t, unusedLocations, 6)
 
 		key = &MasterKey{Recipient: mockRecipient + "abc"}
 		got, unusedLocations, errs = key.loadIdentities()
 		assert.Len(t, errs, 0)
 		assert.Len(t, got, 0)
-		assert.Len(t, unusedLocations, 6)
+		assert.Len(t, unusedLocations, 7)
 	})
 
 	t.Run("cmd error", func(t *testing.T) {
@@ -543,7 +573,7 @@ func TestMasterKey_loadIdentities(t *testing.T) {
 		assert.Error(t, errs[0])
 		assert.ErrorContains(t, errs[0], "failed to execute command meow")
 		assert.Nil(t, got)
-		assert.Len(t, unusedLocations, 6)
+		assert.Len(t, unusedLocations, 7)
 	})
 }
 


### PR DESCRIPTION
Hello! This PR adds support for a new environment variable `SOPS_AGE_SSH_PRIVATE_KEY_CMD` that functions similarly to `SOPS_AGE_KEY_CMD`. The value of this variable is executed and the output is used to derive an age key; the idea is for it to be used along with a password manager.

The README was updated with detail on this env var, tests were added that pass, and I also manually built and tested on macOS via `make install`.

Please let me know if you have any questions or would like anything changed.

Closes #1851.