### PR TITLE
Add Go 1.26 to CI; use for release

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [linux, darwin, windows]
         arch: [amd64, arm64]
-        go-version: ['1.24', '1.25']
+        go-version: ['1.24', '1.25', '1.26']
         exclude:
           - os: windows
             arch: arm64
@@ -85,7 +85,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        go-version: ['1.25']
+        go-version: ['1.26']
     env:
       VAULT_VERSION: "1.14.0"
       VAULT_TOKEN: "root"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: 1.25
+          go-version: 1.26
           cache: false
 
       - name: Setup Syft


### PR DESCRIPTION
Golang 1.26.0 has been released a few days ago.