### PR TITLE
Release 3.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Improvements:
   [#2029](https://github.com/getsops/sops/pull/2029), [#2037](https://github.com/getsops/sops/pull/2037),
   [#2043](https://github.com/getsops/sops/pull/2043), [#2047](https://github.com/getsops/sops/pull/2047),
   [#2050](https://github.com/getsops/sops/pull/2050), [#2059](https://github.com/getsops/sops/pull/2059),
-  [#2074](https://github.com/getsops/sops/pull/2074)).
+  [#2074](https://github.com/getsops/sops/pull/2074), [#2078](https://github.com/getsops/sops/pull/2078)).
 * Fix mistakes in `--help` output ([#1975](https://github.com/getsops/sops/pull/1975),
   [#1963](https://github.com/getsops/sops/pull/1963)).
 * Improve documentation ([#1997](https://github.com/getsops/sops/pull/1997)).

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Version represents the value of the current semantic version.
-var Version = "3.11.0"
+var Version = "3.12.0"
 
 // PrintVersion prints the current version of sops. If the flag
 // `--disable-version-check` is set or if the environment variable


### PR DESCRIPTION
I wrote the changelog assuming that #2071 gets merged. If it isn't, or if it's adjusted, the changelog needs to be adjusted accordingly.

The release process is described here: https://github.com/getsops/sops/blob/main/docs/release.md#preparation

Closes #2064
Closes #2062
Closes #2057
Closes #2053
Closes #1998
