### PR TITLE
CI: Rearrange steps; disable setup-go's caching

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -28,16 +28,17 @@ jobs:
       VAULT_TOKEN: "root"
       VAULT_ADDR: "http://127.0.0.1:8200"
     steps:
-      - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
-        with:
-          go-version: ${{ matrix.go-version }}
-        id: go
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: false
+        id: go
 
       - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:


### PR DESCRIPTION
Right now the main test emits a lot of warnings https://github.com/getsops/sops/actions/runs/22272667513:

> Restore cache failed: Dependencies file is not found in /home/runner/work/sops/sops. Supported file pattern: go.sum

This comes from the setup-go action because we run it *before* doing the checkout. But then we're already doing the caching ourselves. This PR rearranges the steps to the recommended order by setup-go (first checkout, then setup-go) and disables setup-go's caching.

(Maybe we should also drop our caching and rely on setup-go's caching?)