### PR TITLE
sops exec-file: make sure to set GID to correct value instead of UID

### DIFF
--- a/cmd/sops/subcommand/exec/exec_unix.go
+++ b/cmd/sops/subcommand/exec/exec_unix.go
@@ -49,8 +49,9 @@ func SwitchUser(username string) {
 	}
 
 	uid, _ := strconv.Atoi(user.Uid)
+	gid, _ := strconv.Atoi(user.Gid)
 
-	err = syscall.Setgid(uid)
+	err = syscall.Setgid(gid)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -65,7 +66,7 @@ func SwitchUser(username string) {
 		log.Fatal(err)
 	}
 
-	err = syscall.Setregid(uid, uid)
+	err = syscall.Setregid(gid, gid)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
When using `sops exec-file`, currently the user's UID is used as the GID for the `setgid` and `setregid` syscalls. Use the user's GID instead.