### PR TITLE
sops exec-file: improve error handling, reject non-local paths in `--filename`

### DIFF
--- a/cmd/sops/subcommand/exec/exec.go
+++ b/cmd/sops/subcommand/exec/exec.go
@@ -35,25 +35,25 @@ type ExecOpts struct {
 	Env         []string
 }
 
-func GetFile(dir, filename string) *os.File {
+func GetFile(dir, filename string) (*os.File, error) {
 	// If no filename is provided, create a random one based on FallbackFilename
 	if filename == "" {
 		handle, err := os.CreateTemp(dir, FallbackFilename)
 		if err != nil {
-			log.Fatal(err)
+			return nil, err
 		}
-		return handle
+		return handle, nil
 	}
 	// If a filename is provided, use that one
 	handle, err := os.Create(filepath.Join(dir, filename))
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	// read+write for owner only
 	if err = handle.Chmod(0600); err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
-	return handle
+	return handle, nil
 }
 
 func ExecWithFile(opts ExecOpts) error {
@@ -68,7 +68,7 @@ func ExecWithFile(opts ExecOpts) error {
 
 	dir, err := os.MkdirTemp("", ".sops")
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	defer os.RemoveAll(dir)
 
@@ -80,12 +80,18 @@ func ExecWithFile(opts ExecOpts) error {
 		if filename == "" {
 			filename = FallbackFilename
 		}
-		filename = GetPipe(dir, filename)
+		filename, err = GetPipe(dir, filename)
+		if err != nil {
+			return err
+		}
 		go WritePipe(filename, opts.Plaintext)
 	} else {
 		// GetFile handles opts.Filename == "" specially, that's why we have
 		// to pass in opts.Filename without handling the fallback here
-		handle := GetFile(dir, opts.Filename)
+		handle, err := GetFile(dir, opts.Filename)
+		if err != nil {
+			return err
+		}
 		handle.Write(opts.Plaintext)
 		handle.Close()
 		filename = handle.Name()

--- a/cmd/sops/subcommand/exec/exec.go
+++ b/cmd/sops/subcommand/exec/exec.go
@@ -72,6 +72,12 @@ func ExecWithFile(opts ExecOpts) error {
 	}
 	defer os.RemoveAll(dir)
 
+	if opts.Filename != "" {
+		if filepath.IsAbs(opts.Filename) || !filepath.IsLocal(opts.Filename) {
+			return fmt.Errorf("The provided filename is not a local path.")
+		}
+	}
+
 	var filename string
 	if opts.Fifo {
 		// fifo handling needs to be async, even opening to write

--- a/cmd/sops/subcommand/exec/exec_unix.go
+++ b/cmd/sops/subcommand/exec/exec_unix.go
@@ -32,14 +32,14 @@ func WritePipe(pipe string, contents []byte) {
 	handle.Close()
 }
 
-func GetPipe(dir, filename string) string {
+func GetPipe(dir, filename string) (string, error) {
 	tmpfn := filepath.Join(dir, filename)
 	err := syscall.Mkfifo(tmpfn, 0600)
 	if err != nil {
-		log.Fatal(err)
+		return "", err
 	}
 
-	return tmpfn
+	return tmpfn, nil
 }
 
 func SwitchUser(username string) {

--- a/cmd/sops/subcommand/exec/exec_windows.go
+++ b/cmd/sops/subcommand/exec/exec_windows.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"fmt"
 	"os/exec"
 )
 
@@ -17,9 +18,8 @@ func WritePipe(pipe string, contents []byte) {
 	log.Fatal("fifos are not available on windows")
 }
 
-func GetPipe(dir, filename string) string {
-	log.Fatal("fifos are not available on windows")
-	return ""
+func GetPipe(dir, filename string) (string, error) {
+	return "", fmt.Errorf("fifos are not available on windows")
 }
 
 func SwitchUser(username string) {


### PR DESCRIPTION
1. The current error handling is not great; errors are printed, but execution continues. Instead, fail on errors.
2. When `--filename` contains a path, right now the code does not check whether the path [is local](https://pkg.go.dev/path/filepath#IsLocal).