### PR TITLE
Obtain `--indent` global flag value and pass it to store configs

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -2388,8 +2388,8 @@ func outputStore(context *cli.Context, path string) (common.Store, error) {
 	if err != nil {
 		return nil, err
 	}
-	if context.IsSet("indent") {
-		indent := context.Int("indent")
+	if context.GlobalIsSet("indent") {
+		indent := context.GlobalInt("indent")
 		storesConf.YAML.Indent = indent
 		storesConf.JSON.Indent = indent
 		storesConf.JSONBinary.Indent = indent


### PR DESCRIPTION
To change number of spaces per indent level by command line flag. The current version (3.12.2) neglects `--indent` flag.
(Setting indent in `.sops.yaml` works as expected.)

To reproduce:
- Suppose I have an encrypted file (with age):

  ```
  $ age-keygen >key
  $ cat plain.json
  {
    "a": "b"
  }
  $ sops encrypt --age "$(age-keygen -y key)" plain.json --output enc.json
  ```

- Decrypting the file with and without `--indent=2` gives the same output (indented with TABs in both cases):

  ```
  $ SOPS_AGE_KEY_FILE=key sops --indent=2 decrypt enc.json
  {
  	"a": "b"
  }
  $ SOPS_AGE_KEY_FILE=key sops decrypt enc.json
  {
  	"a": "b"
  }
  ```
