### PR TITLE
Add YAML formatting options: compact array indent and document start marker

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -1864,6 +1864,10 @@ func main() {
 			Usage: "the number of spaces to indent YAML or JSON encoded file",
 		},
 		cli.BoolFlag{
+			Name:  "compact-array-indent",
+			Usage: "use compact YAML array indentation where '- ' is considered part of the indentation",
+		},
+		cli.BoolFlag{
 			Name:  "verbose",
 			Usage: "Enable verbose logging output",
 		},
@@ -2393,6 +2397,9 @@ func outputStore(context *cli.Context, path string) (common.Store, error) {
 		storesConf.YAML.Indent = indent
 		storesConf.JSON.Indent = indent
 		storesConf.JSONBinary.Indent = indent
+	}
+	if context.GlobalBool("compact-array-indent") {
+		storesConf.YAML.CompactArrayIndent = true
 	}
 
 	return common.DefaultStoreForPathOrFormat(storesConf, path, context.String("output-type")), nil

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -1868,6 +1868,10 @@ func main() {
 			Usage: "use compact YAML array indentation where '- ' is considered part of the indentation",
 		},
 		cli.BoolFlag{
+			Name:  "document-start-marker",
+			Usage: "prepend the YAML document start marker '---' to the output",
+		},
+		cli.BoolFlag{
 			Name:  "verbose",
 			Usage: "Enable verbose logging output",
 		},
@@ -2400,6 +2404,9 @@ func outputStore(context *cli.Context, path string) (common.Store, error) {
 	}
 	if context.GlobalBool("compact-array-indent") {
 		storesConf.YAML.CompactArrayIndent = true
+	}
+	if context.GlobalBool("document-start-marker") {
+		storesConf.YAML.DocumentStartMarker = true
 	}
 
 	return common.DefaultStoreForPathOrFormat(storesConf, path, context.String("output-type")), nil

--- a/config/config.go
+++ b/config/config.go
@@ -112,7 +112,8 @@ type JSONBinaryStoreConfig struct {
 }
 
 type YAMLStoreConfig struct {
-	Indent int `yaml:"indent"`
+	Indent             int  `yaml:"indent"`
+	CompactArrayIndent bool `yaml:"compact_array_indent"`
 }
 
 type StoresConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -112,8 +112,9 @@ type JSONBinaryStoreConfig struct {
 }
 
 type YAMLStoreConfig struct {
-	Indent             int  `yaml:"indent"`
-	CompactArrayIndent bool `yaml:"compact_array_indent"`
+	Indent              int  `yaml:"indent"`
+	CompactArrayIndent  bool `yaml:"compact_array_indent"`
+	DocumentStartMarker bool `yaml:"document_start_marker"`
 }
 
 type StoresConfig struct {

--- a/stores/yaml/store.go
+++ b/stores/yaml/store.go
@@ -380,6 +380,9 @@ func (store *Store) EmitPlainFile(branches sops.TreeBranches) ([]byte, error) {
 		return nil, err
 	}
 	e.SetIndent(indent)
+	if store.config.CompactArrayIndent {
+		e.CompactSeqIndent()
+	}
 	for _, branch := range branches {
 		// Document root
 		var doc = yaml.Node{}

--- a/stores/yaml/store.go
+++ b/stores/yaml/store.go
@@ -400,6 +400,9 @@ func (store *Store) EmitPlainFile(branches sops.TreeBranches) ([]byte, error) {
 		}
 	}
 	e.Close()
+	if store.config.DocumentStartMarker && !bytes.HasPrefix(b.Bytes(), []byte("---")) {
+		return append([]byte("---\n"), b.Bytes()...), nil
+	}
 	return b.Bytes(), nil
 }
 

--- a/stores/yaml/store_test.go
+++ b/stores/yaml/store_test.go
@@ -541,6 +541,64 @@ func TestCompactArrayIndentDisabled(t *testing.T) {
 	assert.Equal(t, string(in), string(bytes))
 }
 
+func TestDocumentStartMarker(t *testing.T) {
+	in := []byte(`key: value
+nested:
+    list:
+        - a
+        - b
+`)
+	expected := []byte(`---
+key: value
+nested:
+    list:
+        - a
+        - b
+`)
+	branches, err := (&Store{}).LoadPlainFile(in)
+	assert.Nil(t, err)
+	bytes, err := (&Store{
+		config: config.YAMLStoreConfig{
+			DocumentStartMarker: true,
+		},
+	}).EmitPlainFile(branches)
+	assert.Nil(t, err)
+	assert.Equal(t, string(expected), string(bytes))
+}
+
+func TestDocumentStartMarkerMultiDoc(t *testing.T) {
+	in := []byte(`---
+key1: value1
+---
+key2: value2`)
+	expected := []byte(`---
+key1: value1
+---
+key2: value2
+`)
+	branches, err := (&Store{}).LoadPlainFile(in)
+	assert.Nil(t, err)
+	bytes, err := (&Store{
+		config: config.YAMLStoreConfig{
+			DocumentStartMarker: true,
+		},
+	}).EmitPlainFile(branches)
+	assert.Nil(t, err)
+	assert.Equal(t, string(expected), string(bytes))
+}
+
+func TestDocumentStartMarkerDisabled(t *testing.T) {
+	in := []byte(`key: value
+`)
+	branches, err := (&Store{}).LoadPlainFile(in)
+	assert.Nil(t, err)
+	bytes, err := (&Store{}).EmitPlainFile(branches)
+	assert.Nil(t, err)
+	assert.Equal(t, string(in), string(bytes))
+	// Verify no '---' was prepended
+	assert.False(t, len(bytes) > 3 && string(bytes[:3]) == "---")
+}
+
 func TestHasSopsTopLevelKey(t *testing.T) {
 	ok := (&Store{}).HasSopsTopLevelKey(sops.TreeBranch{
 		sops.TreeItem{

--- a/stores/yaml/store_test.go
+++ b/stores/yaml/store_test.go
@@ -440,6 +440,107 @@ func TestIndent1(t *testing.T) {
 	assert.Equal(t, INDENT_1_OUT, bytes)
 }
 
+func TestCompactArrayIndent(t *testing.T) {
+	in := []byte(`spec:
+    rules:
+        - host: example.com
+          http:
+              paths:
+                  - path: /api
+                    backend:
+                        serviceName: api
+                  - path: /web
+                    backend:
+                        serviceName: web
+    tags:
+        - production
+        - web
+`)
+	// With default indent (4) and CompactSeqIndent, '- ' is considered
+	// part of the indentation, so arrays are indented by (indent - 2) spaces.
+	expected := []byte(`spec:
+    rules:
+      - host: example.com
+        http:
+            paths:
+              - path: /api
+                backend:
+                    serviceName: api
+              - path: /web
+                backend:
+                    serviceName: web
+    tags:
+      - production
+      - web
+`)
+	branches, err := (&Store{}).LoadPlainFile(in)
+	assert.Nil(t, err)
+	bytes, err := (&Store{
+		config: config.YAMLStoreConfig{
+			CompactArrayIndent: true,
+		},
+	}).EmitPlainFile(branches)
+	assert.Nil(t, err)
+	assert.Equal(t, string(expected), string(bytes))
+}
+
+func TestCompactArrayIndentWithIndent2(t *testing.T) {
+	// With indent 2, compact array indent produces arrays flush with the parent key.
+	in := []byte(`spec:
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - path: /api
+            backend:
+              serviceName: api
+  tags:
+    - production
+    - web
+`)
+	expected := []byte(`spec:
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - path: /api
+        backend:
+          serviceName: api
+  tags:
+  - production
+  - web
+`)
+	branches, err := (&Store{}).LoadPlainFile(in)
+	assert.Nil(t, err)
+	bytes, err := (&Store{
+		config: config.YAMLStoreConfig{
+			Indent:             2,
+			CompactArrayIndent: true,
+		},
+	}).EmitPlainFile(branches)
+	assert.Nil(t, err)
+	assert.Equal(t, string(expected), string(bytes))
+}
+
+func TestCompactArrayIndentDisabled(t *testing.T) {
+	in := []byte(`spec:
+    rules:
+        - host: example.com
+          http:
+            paths:
+                - path: /api
+`)
+	branches, err := (&Store{}).LoadPlainFile(in)
+	assert.Nil(t, err)
+	bytes, err := (&Store{
+		config: config.YAMLStoreConfig{
+			CompactArrayIndent: false,
+		},
+	}).EmitPlainFile(branches)
+	assert.Nil(t, err)
+	assert.Equal(t, string(in), string(bytes))
+}
+
 func TestHasSopsTopLevelKey(t *testing.T) {
 	ok := (&Store{}).HasSopsTopLevelKey(sops.TreeBranch{
 		sops.TreeItem{


### PR DESCRIPTION
Add two new YAML store configuration options that address long-standing formatting requests:

- `compact_array_indent` - Treats the `- ` array indicator as part of the indentation. With `indent: 2`, this produces arrays flush with their parent key, matching the style used by Kubernetes manifests and common YAML linters. Exposes yaml.v3's `CompactSeqIndent()` encoder setting.

- `document_start_marker` - Prepends `---` to YAML output. SOPS currently strips this during encryption, which often breaks linting tools that need/want it, like `yamlfmt`, `yamllint`, and `ytt`.

Both options can be set via `.sops.yaml` or CLI flags:

```yaml
stores:
    yaml:
        compact_array_indent: true
        document_start_marker: true
```

`--compact-array-indent`
`--document-start-marker`

Refs #514, Refs #864, Refs #1066, Refs #1158

Added tests for:

- Compact array indent: default indent (4), indent 2, and disabled
- Document start marker: single doc, multi-doc, and disabled

Update: I see docs have been moved to a new repo, I have removed them from here and will follow up with a PR to that repo if this gets merged.