### PR TITLE
Release 3.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 3.13.1
+
+Improvements:
+
+* Dependency updates ([#2178](https://github.com/getsops/sops/pull/2178)).
+* Make sure all files are formatted ([#2181](https://github.com/getsops/sops/pull/2181)).
+* The documentation for SOPS can now be found on [getsops.io](https://getsops.io)
+  instead of the project's README ([#2083](https://github.com/getsops/sops/pull/2083)).
+
+Bugfixes:
+
+* Fix scheme for determining gpg-agent cache keys for age password-protected
+  keys to avoid too large keys due to percent encoding ([#2180](https://github.com/getsops/sops/pull/2180)).
+
+Project changes:
+
+* CI dependency updates ([#2177](https://github.com/getsops/sops/pull/2177)).
+
 ## 3.13.0
 
 Improvements:

--- a/docs/release.md
+++ b/docs/release.md
@@ -73,3 +73,5 @@ This configuration is quite sophisticated, and ensures at least the following:
 
 - [ ] Ensure the release is built successfully on GitHub Actions. This will
   automatically create a release on GitHub.
+- [ ] In [the getsops/docs repository](https://github.com/getsops/docs/),
+  merge `main` into `stable` and push `stable` to update [getsops.io](https://getsops.io/).

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Version represents the value of the current semantic version.
-var Version = "3.13.0"
+var Version = "3.13.1"
 
 // PrintVersion prints the current version of sops. If the flag
 // `--disable-version-check` is set or if the environment variable


### PR DESCRIPTION
Following https://github.com/getsops/sops/blob/main/docs/release.md#preparation as always.