### PR TITLE
Allow CLI flags to override config file settings with empty values

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -2125,23 +2125,26 @@ func getEncryptConfig(c *cli.Context, fileName string, inputStore common.Store, 
 		}
 	}
 	if optionalConfig != nil {
-		// command line options have precedence
-		if unencryptedSuffix == "" {
+		// command line options have precedence over config file settings.
+		// Use IsSet to distinguish "flag not provided" from "flag explicitly
+		// set to empty string", so that --encrypted-regex="" properly
+		// overrides a config file value (fixes #617).
+		if !c.IsSet("unencrypted-suffix") && unencryptedSuffix == "" {
 			unencryptedSuffix = optionalConfig.UnencryptedSuffix
 		}
-		if encryptedSuffix == "" {
+		if !c.IsSet("encrypted-suffix") && encryptedSuffix == "" {
 			encryptedSuffix = optionalConfig.EncryptedSuffix
 		}
-		if encryptedRegex == "" {
+		if !c.IsSet("encrypted-regex") && encryptedRegex == "" {
 			encryptedRegex = optionalConfig.EncryptedRegex
 		}
-		if unencryptedRegex == "" {
+		if !c.IsSet("unencrypted-regex") && unencryptedRegex == "" {
 			unencryptedRegex = optionalConfig.UnencryptedRegex
 		}
-		if encryptedCommentRegex == "" {
+		if !c.IsSet("encrypted-comment-regex") && encryptedCommentRegex == "" {
 			encryptedCommentRegex = optionalConfig.EncryptedCommentRegex
 		}
-		if unencryptedCommentRegex == "" {
+		if !c.IsSet("unencrypted-comment-regex") && unencryptedCommentRegex == "" {
 			unencryptedCommentRegex = optionalConfig.UnencryptedCommentRegex
 		}
 		if !macOnlyEncrypted {


### PR DESCRIPTION
## Problem

When a user passes `--encrypted-regex=''` on the command line, the intent is to unset the config file's `encrypted_regex` setting. Previously, the code checked if the CLI value was empty string and fell back to the config file value, making it impossible to override config settings with empty strings.

This affects all six suffix/regex flags: `--encrypted-suffix`, `--unencrypted-suffix`, `--encrypted-regex`, `--unencrypted-regex`, `--encrypted-comment-regex`, `--unencrypted-comment-regex`.

Fixes #617

## Root Cause

In `getEncryptConfig()` (`cmd/sops/main.go`), the precedence logic was:

```go
if encryptedRegex == "" {
    encryptedRegex = optionalConfig.EncryptedRegex
}
```

This treats "flag not provided" and "flag explicitly set to empty" identically.

## Fix

Use `cli.Context.IsSet()` to distinguish between "flag not provided" (use config) and "flag explicitly set to empty string" (use CLI value):

```go
if !c.IsSet("encrypted-regex") && encryptedRegex == "" {
    encryptedRegex = optionalConfig.EncryptedRegex
}
```

This pattern is already used elsewhere in the codebase (`c.GlobalIsSet("indent")` at line 2391).

## Testing

- `go build ./cmd/sops/` passes
- `go test ./config/` passes
- `go test ./... -short` passes (only pre-existing PGP keyring test fails, unrelated to this change)
