### PR TITLE
Restrict markdownlint to 0.15.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,11 +5,12 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-    # Only consider changes to documentation
+    # Only consider changes to documentation, or this workflow
     paths:
       - '**/*.md'
       - '**/*.rst'
       - '**/*.txt'
+      - .github/workflows/docs.yml
   schedule:
     - cron: '25 6 * * 3'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install rstcheck and markdownlint
         run: |
           pip install rstcheck
-          sudo gem install mdl
+          sudo gem install mdl -v '0.15.0'
 
       - name: Run rstcheck on all RST files
         run: make checkrst


### PR DESCRIPTION
Since version 0.16.0 markdownline is more strict on line length limits, which causes a lot of issues in our .md documents. Pinning to the previous release 0.15.0 for now.

Ref: https://github.com/markdownlint/markdownlint/issues/573