### PR TITLE
test: unset all age env vars in make test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ checkmd: $(MD_FILES)
 .PHONY: test
 test: vendor
 	gpg --import pgp/sops_functional_tests_key.asc 2>&1 1>/dev/null || exit 0
-	unset SOPS_AGE_KEY_FILE; unset SOPS_AGE_KEY_CMD; LANG=en_US.UTF-8 $(GO) test $(GO_TEST_FLAGS) ./...
+	unset SOPS_AGE_KEY; unset SOPS_AGE_KEY_FILE; unset SOPS_AGE_KEY_CMD; unset SOPS_AGE_RECIPIENT; unset SOPS_AGE_SSH_PRIVATE_KEY_FILE; unset SOPS_AGE_SSH_PRIVATE_KEY_CMD; LANG=en_US.UTF-8 $(GO) test $(GO_TEST_FLAGS) ./...
 
 .PHONY: showcoverage
 showcoverage: test


### PR DESCRIPTION
## What this fixes

`make test` unsets `SOPS_AGE_KEY_FILE` and `SOPS_AGE_KEY_CMD` to isolate the test environment, but the `age` keysource reads four other environment variables that are not unset: `SOPS_AGE_KEY`, `SOPS_AGE_RECIPIENT`, `SOPS_AGE_SSH_PRIVATE_KEY_FILE`, and `SOPS_AGE_SSH_PRIVATE_KEY_CMD`.

When a developer has any of these set in their shell, `TestMasterKey_loadIdentities` fails spuriously. The subtests assert an exact `unusedLocations` count, so any inherited age variable throws the count off, and the SSH variants additionally try to open or run the inherited key. The reported symptom (#1990) is:

```
failed to open file: open /etc/ssh/ssh_host_ed25519_key: permission denied
```

which happens because a developer's `SOPS_AGE_SSH_PRIVATE_KEY_FILE` leaks into the test run.

## The change

Unset the full set of age environment variables the `test` target intends to isolate, matching the existing `unset ...; unset ...;` style already on that line:

```make
unset SOPS_AGE_KEY; unset SOPS_AGE_KEY_FILE; unset SOPS_AGE_KEY_CMD; unset SOPS_AGE_RECIPIENT; unset SOPS_AGE_SSH_PRIVATE_KEY_FILE; unset SOPS_AGE_SSH_PRIVATE_KEY_CMD; LANG=en_US.UTF-8 $(GO) test $(GO_TEST_FLAGS) ./...
```

I went beyond just `SOPS_AGE_SSH_PRIVATE_KEY_FILE` because `SOPS_AGE_SSH_PRIVATE_KEY_CMD` is the symmetric sibling and produces the identical class of failure, and `SOPS_AGE_KEY` / `SOPS_AGE_RECIPIENT` break the same exact-count assertions if inherited. The six variables here are exactly the ones the `age` package looks up in `age/keysource.go`. Happy to narrow this to only `SOPS_AGE_SSH_PRIVATE_KEY_FILE` if you would prefer the minimal change.

## How I verified

With `SOPS_AGE_SSH_PRIVATE_KEY_FILE` pointing at a non-age file, `go test -run TestMasterKey_loadIdentities ./age/` reproduces the failure from the issue. Running the same package after the unsets in this PR passes. I also confirmed `SOPS_AGE_SSH_PRIVATE_KEY_CMD` triggers the same failure, which is why it is unset here too. CI runs the suite through `make test`, so it picks up this isolation as well.

Fixes #1990
