### PR TITLE
fix: handle pointers when serializing context

### DIFF
--- a/stores/metadata.go
+++ b/stores/metadata.go
@@ -184,6 +184,11 @@ func (mapKeys byName) Less(i, j int) bool {
 func goToSops(value interface{}) (interface{}, error) {
 	val := reflect.ValueOf(value)
 	switch val.Kind() {
+	case reflect.Pointer:
+		if val.IsNil() {
+			return nil, nil
+		}
+		return goToSops(val.Elem().Interface())
 	case reflect.Array, reflect.Slice:
 		result := make([]interface{}, val.Len())
 		for j := 0; j < val.Len(); j++ {

--- a/stores/metadata_test.go
+++ b/stores/metadata_test.go
@@ -1007,4 +1007,35 @@ func TestExtractMetadata(t *testing.T) {
 }
 
 func TestSerializeMetadata(t *testing.T) {
+	// KMS EncryptionContext is map[string]*string; values must serialize as strings, not pointer addresses.
+	tenant := "example-tenant"
+	tree := sops.Tree{
+		Branches: sops.TreeBranches{sops.TreeBranch{}},
+		Metadata: sops.Metadata{
+			LastModified: time.Unix(0, 0).UTC(),
+			Version:      "3.0.0",
+			KeyGroups: []sops.KeyGroup{
+				{
+					&kms.MasterKey{
+						Arn:          "arn:aws:kms:us-east-1:000000000000:key/00000000-0000-0000-0000-000000000000",
+						CreationDate: time.Unix(0, 0).UTC(),
+						EncryptionContext: map[string]*string{
+							"tenant": &tenant,
+						},
+					},
+				},
+			},
+		},
+	}
+	branches, err := SerializeMetadata(tree, MetadataOpts{Flatten: MetadataFlattenFull})
+	assert.Nil(t, err)
+	// Find the flattened context key and assert its value is the string "example-tenant", not a pointer address.
+	var contextValue interface{}
+	for _, item := range branches[0] {
+		if item.Key == "sops_kms__list_0__map_context__map_tenant" {
+			contextValue = item.Value
+			break
+		}
+	}
+	assert.Equal(t, "example-tenant", contextValue, "KMS encryption context value must be a string, not a pointer")
 }


### PR DESCRIPTION
Starting with the change #2120 we've run into the issue that when saving a SOPS files the context values of a provider (in our case AWS KMS using `tenant`) gets mangled and a pointer value gets written into the encrypted file.

If such a invalid file is committed it cannot be decrypted anymore by `sops` since it lacks the proper `context` to do so.

i also took the liberty to add a method body to `TestSerializeMetadata` even if it just tests the AWS KMS case i've run into for now. -> Should this be a more specific test?