### PR TITLE
docs: fix typo in exec-file --filename help text

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -315,7 +315,7 @@ func main() {
 				},
 				cli.StringFlag{
 					Name:  "filename",
-					Usage: fmt.Sprintf("filename for the temporarily file (default: %s)", exec.FallbackFilename),
+					Usage: fmt.Sprintf("filename for the temporary file (default: %s)", exec.FallbackFilename),
 				},
 				cli.StringFlag{
 					Name:   "decryption-order",


### PR DESCRIPTION
The exec-file --filename help read "filename for the temporarily file"; corrected to "temporary", matching the command's own usage string.
