### PR TITLE
Fix issue when changing user in exec subcommands

### DIFF
--- a/cmd/sops/subcommand/exec/exec.go
+++ b/cmd/sops/subcommand/exec/exec.go
@@ -57,7 +57,9 @@ func GetFile(dir, filename string) (*os.File, error) {
 }
 
 func ExecWithFile(opts ExecOpts) error {
+	var userEnv []string
 	if opts.User != "" {
+		userEnv = UserEnv(opts.User)
 		SwitchUser(opts.User)
 	}
 
@@ -107,6 +109,7 @@ func ExecWithFile(opts ExecOpts) error {
 	if !opts.Pristine {
 		env = os.Environ()
 	}
+	env = append(env, userEnv...)
 	env = append(env, opts.Env...)
 
 	placeholdered := strings.Replace(opts.Command, "{}", filename, -1)
@@ -125,7 +128,9 @@ func ExecWithFile(opts ExecOpts) error {
 }
 
 func ExecWithEnv(opts ExecOpts) error {
+	var userEnv []string
 	if opts.User != "" {
+		userEnv = UserEnv(opts.User)
 		SwitchUser(opts.User)
 	}
 
@@ -150,6 +155,7 @@ func ExecWithEnv(opts ExecOpts) error {
 		env = append(env, string(line))
 	}
 
+	env = append(env, userEnv...)
 	env = append(env, opts.Env...)
 
 	if opts.SameProcess {

--- a/cmd/sops/subcommand/exec/exec_unix.go
+++ b/cmd/sops/subcommand/exec/exec_unix.go
@@ -42,6 +42,18 @@ func GetPipe(dir, filename string) (string, error) {
 	return tmpfn, nil
 }
 
+func UserEnv(username string) []string {
+	u, err := user.Lookup(username)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return []string{
+		"HOME=" + u.HomeDir,
+		"USER=" + u.Username,
+		"LOGNAME=" + u.Username,
+	}
+}
+
 func SwitchUser(username string) {
 	user, err := user.Lookup(username)
 	if err != nil {

--- a/cmd/sops/subcommand/exec/exec_unix_test.go
+++ b/cmd/sops/subcommand/exec/exec_unix_test.go
@@ -1,0 +1,115 @@
+//go:build !windows
+// +build !windows
+
+package exec
+
+import (
+	"os"
+	"os/user"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserEnvReturnsCorrectVars(t *testing.T) {
+	currentUser, err := user.Current()
+	require.NoError(t, err)
+
+	env := UserEnv(currentUser.Username)
+
+	assert.Contains(t, env, "HOME="+currentUser.HomeDir)
+	assert.Contains(t, env, "USER="+currentUser.Username)
+	assert.Contains(t, env, "LOGNAME="+currentUser.Username)
+	assert.Len(t, env, 3)
+}
+
+func TestUserEnvDoesNotModifyProcessEnv(t *testing.T) {
+	currentUser, err := user.Current()
+	require.NoError(t, err)
+
+	originalHome := os.Getenv("HOME")
+
+	UserEnv(currentUser.Username)
+
+	assert.Equal(t, originalHome, os.Getenv("HOME"),
+		"HOME should not be modified in the current process")
+}
+
+func TestExecWithFilePassesUserEnvToChild(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("skipping test that requires root privileges")
+	}
+
+	currentUser, err := user.Current()
+	require.NoError(t, err)
+
+	originalHome := os.Getenv("HOME")
+
+	err = ExecWithFile(ExecOpts{
+		Command:   "env | grep ^HOME=",
+		Plaintext: []byte("hello"),
+		User:      currentUser.Username,
+		Fifo:      false,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, originalHome, os.Getenv("HOME"),
+		"ExecWithFile should not modify HOME in the current process")
+}
+
+func TestExecWithEnvPassesUserEnvToChild(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("skipping test that requires root privileges")
+	}
+
+	currentUser, err := user.Current()
+	require.NoError(t, err)
+
+	originalHome := os.Getenv("HOME")
+
+	err = ExecWithEnv(ExecOpts{
+		Command:   "true",
+		Plaintext: []byte{},
+		User:      currentUser.Username,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, originalHome, os.Getenv("HOME"),
+		"ExecWithEnv should not modify HOME in the current process")
+}
+
+func TestExecWithFilePristineIncludesUserEnv(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("skipping test that requires root privileges")
+	}
+
+	currentUser, err := user.Current()
+	require.NoError(t, err)
+
+	err = ExecWithFile(ExecOpts{
+		Command:   "env | grep -q ^HOME=",
+		Plaintext: []byte("hello"),
+		User:      currentUser.Username,
+		Pristine:  true,
+		Fifo:      false,
+	})
+	require.NoError(t, err, "child should have HOME even with --pristine when --user is set")
+}
+
+func TestExecWithEnvPristineIncludesUserEnv(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("skipping test that requires root privileges")
+	}
+
+	currentUser, err := user.Current()
+	require.NoError(t, err)
+
+	err = ExecWithEnv(ExecOpts{
+		Command:   "env | grep -q ^HOME=",
+		Plaintext: []byte{},
+		User:      currentUser.Username,
+		Pristine:  true,
+	})
+	require.NoError(t, err, "child should have HOME even with --pristine when --user is set")
+}

--- a/cmd/sops/subcommand/exec/exec_windows.go
+++ b/cmd/sops/subcommand/exec/exec_windows.go
@@ -22,6 +22,10 @@ func GetPipe(dir, filename string) (string, error) {
 	return "", fmt.Errorf("fifos are not available on windows")
 }
 
+func UserEnv(username string) []string {
+	return nil
+}
+
 func SwitchUser(username string) {
 	log.Fatal("user switching not available on windows")
 }


### PR DESCRIPTION
Fix exec subcommands (`exec-file` and `exec-env`) to set `HOME`, `USER`, and `LOGNAME` environment variables in the child process when the `--user` flag is used.

## Originating Issue
When using `--user` to run a child process as a different user, `SwitchUser()` changes the UID/GID but leaves the environment variables pointing at the original user. This causes the child process to inherit incorrect values for `HOME`,
  `USER`, and `LOGNAME`, which can break tools that rely on these variables (e.g., resolving `~` or determining the current user).

Example of issue:
```shell
sops exec-env --user=sops test.yml bash
bash: /root/.bashrc: Permission denied
```


  ## Changes
  - Added `UserEnv()` function in `exec_unix.go` that looks up the target user and returns the correct `HOME`, `USER`, and `LOGNAME` environment variables
  - Updated `ExecWithFile()` and `ExecWithEnv()` to capture user environment variables **before** switching the user, then inject them into the child process environment
  - User environment variables are included in both pristine and non-pristine modes when `--user` is set
  - Added a stub `UserEnv()` on Windows (`exec_windows.go`) that fatals, consistent with the existing `SwitchUser()` behavior
  - Added unit tests in `exec_unix_test.go` covering `UserEnv()` output, process environment isolation, and integration with both exec modes in pristine and non-pristine configurations