### PR TITLE
Add --age-key-file flag for the age decryption identity file

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -78,6 +78,13 @@ func main() {
 	cli.VersionPrinter = version.PrintVersion
 	app := cli.NewApp()
 
+	// Bridge --age-key-file into its environment variable before any command
+	// runs, so it applies to every decrypt path (the top-level action as well
+	// as the decrypt/edit/exec-env/exec-file subcommands, which have their own
+	// actions). Like other global flags (e.g. --config, --verbose), it must be
+	// given before the subcommand.
+	app.Before = ageKeyFileFlagBefore
+
 	keyserviceFlags := []cli.Flag{
 		cli.BoolTFlag{
 			Name:   "enable-local-keyservice",
@@ -1734,6 +1741,11 @@ func main() {
 			Usage:  "comma separated list of age recipients",
 			EnvVar: "SOPS_AGE_RECIPIENTS",
 		},
+		cli.StringFlag{
+			Name:   "age-key-file",
+			Usage:  "path to a file containing age identities used for decryption",
+			EnvVar: "SOPS_AGE_KEY_FILE",
+		},
 		cli.BoolFlag{
 			Name:  "in-place, i",
 			Usage: "write output back to the same file instead of stdout",
@@ -2298,6 +2310,28 @@ func getRotateOpts(c *cli.Context, fileName string, inputStore common.Store, out
 		AddMasterKeys:    addMasterKeys,
 		RemoveMasterKeys: rmMasterKeys,
 	}, nil
+}
+
+// ageKeyFileFlagBefore is the app-level Before hook that applies the
+// --age-key-file flag. It runs ahead of every command (the implicit top-level
+// action and each subcommand), so the flag takes effect on all decrypt paths.
+func ageKeyFileFlagBefore(c *cli.Context) error {
+	return applyAgeKeyFileFlag(c.String("age-key-file"))
+}
+
+// applyAgeKeyFileFlag bridges the --age-key-file CLI flag into the
+// SOPS_AGE_KEY_FILE environment variable, which the age keysource reads in
+// loadIdentities to locate the identity file used for decryption. Decrypt-time
+// age identities are reconstructed from a file's metadata, so there is no
+// MasterKey to inject the path into directly; setting the environment the
+// keysource already consumes is the least-invasive way to expose this as a
+// POSIX-style flag. An explicitly passed flag therefore overrides any
+// pre-existing SOPS_AGE_KEY_FILE value. A no-op when the flag is unset.
+func applyAgeKeyFileFlag(ageKeyFile string) error {
+	if ageKeyFile == "" {
+		return nil
+	}
+	return os.Setenv(age.SopsAgeKeyFileEnv, ageKeyFile)
 }
 
 func toExitError(err error) error {

--- a/cmd/sops/main_test.go
+++ b/cmd/sops/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/getsops/sops/v3/age"
+	"github.com/urfave/cli"
+)
+
+func TestApplyAgeKeyFileFlag(t *testing.T) {
+	t.Run("sets the environment when the flag is provided", func(t *testing.T) {
+		// t.Setenv registers restoration of the original value; clearing it
+		// afterwards gives the subtest a known, unset starting point.
+		t.Setenv(age.SopsAgeKeyFileEnv, "")
+		if err := os.Unsetenv(age.SopsAgeKeyFileEnv); err != nil {
+			t.Fatalf("failed to unset %s: %v", age.SopsAgeKeyFileEnv, err)
+		}
+
+		const want = "/path/to/keys.txt"
+		if err := applyAgeKeyFileFlag(want); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := os.Getenv(age.SopsAgeKeyFileEnv); got != want {
+			t.Errorf("%s = %q, want %q", age.SopsAgeKeyFileEnv, got, want)
+		}
+	})
+
+	t.Run("overrides a pre-existing environment value", func(t *testing.T) {
+		t.Setenv(age.SopsAgeKeyFileEnv, "/from/env")
+
+		const want = "/from/flag"
+		if err := applyAgeKeyFileFlag(want); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := os.Getenv(age.SopsAgeKeyFileEnv); got != want {
+			t.Errorf("%s = %q, want %q", age.SopsAgeKeyFileEnv, got, want)
+		}
+	})
+
+	t.Run("leaves the environment untouched when the flag is empty", func(t *testing.T) {
+		const want = "/from/env"
+		t.Setenv(age.SopsAgeKeyFileEnv, want)
+
+		if err := applyAgeKeyFileFlag(""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := os.Getenv(age.SopsAgeKeyFileEnv); got != want {
+			t.Errorf("%s = %q, want %q", age.SopsAgeKeyFileEnv, got, want)
+		}
+	})
+}
+
+// TestAgeKeyFileFlagBefore exercises the actual app.Before hook through a
+// cli.Context carrying the --age-key-file flag. Because the hook is wired to
+// app.Before (not app.Action), it runs for every command path, including the
+// decrypt/exec-env/exec-file subcommands that have their own actions.
+func TestAgeKeyFileFlagBefore(t *testing.T) {
+	t.Setenv(age.SopsAgeKeyFileEnv, "")
+	if err := os.Unsetenv(age.SopsAgeKeyFileEnv); err != nil {
+		t.Fatalf("failed to unset %s: %v", age.SopsAgeKeyFileEnv, err)
+	}
+
+	const want = "/path/to/keys.txt"
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	set.String("age-key-file", "", "")
+	if err := set.Set("age-key-file", want); err != nil {
+		t.Fatalf("failed to set flag: %v", err)
+	}
+
+	if err := ageKeyFileFlagBefore(cli.NewContext(nil, set, nil)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := os.Getenv(age.SopsAgeKeyFileEnv); got != want {
+		t.Errorf("%s = %q, want %q", age.SopsAgeKeyFileEnv, got, want)
+	}
+}


### PR DESCRIPTION
## What

Adds a global `--age-key-file` CLI flag so the age decryption identity file can be supplied on the command
line, not only through the `SOPS_AGE_KEY_FILE` environment variable.

```sh
sops --age-key-file ~/keys/age.txt -d secrets.yaml
sops --age-key-file ~/keys/age.txt decrypt secrets.yaml
sops --age-key-file ~/keys/age.txt exec-env secrets.yaml 'mycmd'
```

Closes #1887.

## Why

On decrypt, age identities are loaded exclusively from the environment in `age/keysource.go`
(`loadIdentities`). The CLI already exposes `--age` for *recipients* (encrypt), but there is no flag for the
identity *file* on decrypt, so the only way to point sops at a key file is to export `SOPS_AGE_KEY_FILE`.
Several users in #1887 noted this is unconventional for a POSIX CLI.

## Scope

Deliberately narrow, addressing @felixfontein's concern in the issue about adding flags for *every* store's
env var: this adds **only** `--age-key-file`, the single variable the issue is about. `--age-key`/`--age-key-cmd`
could follow the same pattern later if desired, but are intentionally left out here.

## How

`--age-key-file` is a global flag (mirroring `--age`, `EnvVar: SOPS_AGE_KEY_FILE`). Decrypt-time age
identities are reconstructed from the file's own metadata, so there is no `MasterKey` to inject the path into
directly; instead an `app.Before` hook writes the flag value into the `SOPS_AGE_KEY_FILE` environment variable
that the keysource already reads in `loadIdentities`. Using `app.Before` (rather than the top-level action)
means it applies to **every** decrypt path — the implicit `sops -d` action and the `decrypt`/`edit`/`exec-env`/
`exec-file` subcommands, which each have their own actions. As with other global flags (`--config`,
`--verbose`), it is given before the subcommand. An explicitly passed flag overrides any pre-existing env
value; when unset, behavior is unchanged.

## Testing

- `cmd/sops/main_test.go`:
  - `applyAgeKeyFileFlag` bridge unit test (set / override-existing / no-op-when-empty).
  - `TestAgeKeyFileFlagBefore` drives the actual `app.Before` hook through a `cli.Context`, proving the flag
    is applied for the subcommand paths (not just the top-level action).
- Manually verified end to end: a file encrypted to an age recipient fails to decrypt with no flag and no
  env, and decrypts via `sops --age-key-file <path> decrypt`, `sops -d --age-key-file <path>`, and
  `sops --age-key-file <path> exec-env` with `SOPS_AGE_KEY_FILE` unset.
- `go test -race ./cmd/sops/ ./age/` passes; `gofmt`/`go vet` clean.

## Notes

- No CHANGELOG entry, matching the repo convention of maintainer-curated release changelogs (recent
  user-facing changes land without per-PR entries) — happy to add one if you'd prefer.
- For `exec-env`/`exec-file`, the path is exported into the spawned child environment (as `SOPS_AGE_KEY_FILE`),
  identical to a user setting that variable directly; it's a path, not key material.
- Happy to open a companion docs PR in getsops/docs for the new flag if this is accepted.

cc @felixfontein (you raised the scoping question on the issue) and @hiddeco (age keysource author).
