### PR TITLE
fix(config): normalize paths before regex matching (fixes #2237)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -510,6 +510,7 @@ func configFromRule(rule *creationRule, kmsEncryptionContext map[string]*string)
 func parseDestinationRuleForFile(conf *configFile, filePath string, kmsEncryptionContext map[string]*string) (*Config, error) {
 	var rule *creationRule
 	var dRule *destinationRule
+	filePath = filepath.ToSlash(filePath)
 
 	if len(conf.DestinationRules) > 0 {
 		for _, r := range conf.DestinationRules {
@@ -580,6 +581,7 @@ func parseCreationRuleForFile(conf *configFile, confPath, filePath string, kmsEn
 
 	// compare file path relative to path of config file
 	filePath = strings.TrimPrefix(filePath, configDir+string(filepath.Separator))
+	filePath = filepath.ToSlash(filePath)
 
 	var rule *creationRule
 

--- a/config/config_windows_test.go
+++ b/config/config_windows_test.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package config
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPathRegexMatchesWindowsPaths(t *testing.T) {
+	conf := parseConfigFile([]byte(`
+creation_rules:
+  - path_regex: '^secrets/.*\.env$'
+    pgp: test
+destination_rules:
+  - path_regex: '^secrets/.*\.env$'
+    s3_bucket: example
+    recreation_rule:
+      pgp: test
+`), t)
+
+	filePath := filepath.Join("secrets", "prod.env")
+	configPath := filepath.Join(t.TempDir(), ".sops.yaml")
+	creationPath := filepath.Join(filepath.Dir(configPath), filePath)
+
+	creationConfig, err := parseCreationRuleForFile(conf, configPath, creationPath, nil)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, "test", creationConfig.KeyGroups[0][0].ToString())
+
+	destinationConfig, err := parseDestinationRuleForFile(conf, filePath, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, destinationConfig.Destination)
+}


### PR DESCRIPTION
## Summary

Fixes #2237. On Windows, creation and destination rule regexes were evaluated against native `\\`-separated paths, so shared `.sops.yaml` rules written with `/` did not match. Normalize the path only at each regex-matching boundary with `filepath.ToSlash`; file-system paths and other configuration behavior remain unchanged.

Adds a Windows-only regression test that uses native `filepath.Join` paths and verifies both creation rules and destination rules match `^secrets/.*\\.env$`.

## Validation

- `go test ./config -run '^TestPathRegexMatchesWindowsPaths$' -count=1`
- `go vet ./config`
- `go build ./cmd/sops`
- `git diff --check`

`go test ./...` is not clean in this local Windows environment because existing age/PGP tests observe preconfigured `SOPS_AGE_KEY`/SSH identities and incompatible GnuPG permissions; it also includes an existing Windows failure in `TestLoadConfigFileWithAmbiguousPath`. The new targeted regression test passes.