### PR TITLE
Don't require a matching creation rule when a key is given explicitly

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -3,6 +3,7 @@ package main // import "github.com/getsops/sops/v3/cmd/sops"
 import (
 	"context"
 	encodingjson "encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -1942,12 +1943,23 @@ func main() {
 		// Load configuration here for backwards compatibility (error out in case of bad config files),
 		// but only when not just decrypting (https://github.com/getsops/sops/issues/868)
 		needsCreationRule := isEncryptMode || isRotateMode || isSetMode || isEditMode
+		// Captured before the `config` local below shadows the `config` package name.
+		errNoMatchingCreationRules := config.ErrNoMatchingCreationRules
 		var config *config.Config
 		if needsCreationRule {
 			kmsEncryptionContext := kms.ParseKMSContext(c.String("encryption-context"))
 			config, err = loadConfig(c, fileNameOverride, kmsEncryptionContext)
 			if err != nil {
-				return toExitError(err)
+				// A config file exists but none of its creation rules match this file.
+				// That's only fatal if we have no other way to get an encryption key:
+				// keyGroups() sources keys straight from CLI flags without consulting
+				// the config at all, so a non-matching config shouldn't block encrypt/
+				// rotate/set/edit when the caller supplied a key explicitly.
+				if errors.Is(err, errNoMatchingCreationRules) && hasExplicitKeyFlags(c) {
+					config, err = nil, nil
+				} else {
+					return toExitError(err)
+				}
 			}
 		}
 
@@ -2121,7 +2133,16 @@ func getEncryptConfig(c *cli.Context, fileName string, inputStore common.Store, 
 	if optionalConfig == nil {
 		optionalConfig, err = loadConfig(c, fileName, nil)
 		if err != nil {
-			return encryptConfig{}, toExitError(err)
+			// A config file exists but none of its creation rules match this file.
+			// That's only fatal if we have no other way to get an encryption key:
+			// keyGroups() below already sources keys straight from these same CLI
+			// flags without consulting the config at all, so a non-matching config
+			// shouldn't block encryption when the caller supplied a key explicitly.
+			if errors.Is(err, config.ErrNoMatchingCreationRules) && hasExplicitKeyFlags(c) {
+				optionalConfig, err = nil, nil
+			} else {
+				return encryptConfig{}, toExitError(err)
+			}
 		}
 	}
 	if optionalConfig != nil {
@@ -2425,6 +2446,14 @@ func parseTreePath(arg string) ([]interface{}, error) {
 	return path, nil
 }
 
+// hasExplicitKeyFlags reports whether the user supplied at least one master-key source
+// directly on the command line, rather than relying on a config file to provide one.
+func hasExplicitKeyFlags(c *cli.Context) bool {
+	return c.String("kms") != "" || c.String("pgp") != "" || c.String("gcp-kms") != "" ||
+		c.String("hckms") != "" || c.String("azure-kv") != "" || c.String("hc-vault-transit") != "" ||
+		c.String("age") != ""
+}
+
 func keyGroups(c *cli.Context, file string, optionalConfig *config.Config) ([]sops.KeyGroup, error) {
 	var kmsKeys []keys.MasterKey
 	var pgpKeys []keys.MasterKey
@@ -2488,7 +2517,7 @@ func keyGroups(c *cli.Context, file string, optionalConfig *config.Config) ([]so
 			ageMasterKeys = append(ageMasterKeys, k)
 		}
 	}
-	if c.String("kms") == "" && c.String("pgp") == "" && c.String("gcp-kms") == "" && c.String("hckms") == "" && c.String("azure-kv") == "" && c.String("hc-vault-transit") == "" && c.String("age") == "" {
+	if !hasExplicitKeyFlags(c) {
 		conf := optionalConfig
 		var err error
 		if conf == nil {
@@ -2544,6 +2573,12 @@ func shamirThreshold(c *cli.Context, file string, optionalConfig *config.Config)
 	conf := optionalConfig
 	if conf == nil {
 		conf, err = loadConfig(c, file, nil)
+		if errors.Is(err, config.ErrNoMatchingCreationRules) && hasExplicitKeyFlags(c) {
+			// A non-matching config doesn't block encryption when a key was supplied
+			// explicitly (see the identical exemption in getEncryptConfig); the caller
+			// is not relying on the config for anything else this function returns.
+			conf, err = nil, nil
+		}
 	}
 	if conf == nil {
 		// This takes care of the following two case:

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ Package config provides a way to find and load SOPS configuration files
 package config //import "github.com/getsops/sops/v3/config"
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -567,6 +568,13 @@ func parseDestinationRuleForFile(conf *configFile, filePath string, kmsEncryptio
 	return config, nil
 }
 
+// ErrNoMatchingCreationRules is returned by parseCreationRuleForFile when a config file
+// has creation rules but none of them match the given file path. Exported as a sentinel
+// so callers that can source keys another way (e.g. explicit --age/--kms/... flags) can
+// tell this apart from other config-loading failures and treat it as "no applicable
+// config" instead of a hard error.
+var ErrNoMatchingCreationRules = errors.New("no matching creation rules found")
+
 func parseCreationRuleForFile(conf *configFile, confPath, filePath string, kmsEncryptionContext map[string]*string) (*Config, error) {
 	// If config file doesn't contain CreationRules (it's empty or only contains DestionationRules), assume it does not exist
 	if conf.CreationRules == nil {
@@ -599,7 +607,7 @@ func parseCreationRuleForFile(conf *configFile, confPath, filePath string, kmsEn
 	}
 
 	if rule == nil {
-		return nil, fmt.Errorf("error loading config: no matching creation rules found")
+		return nil, fmt.Errorf("error loading config: %w", ErrNoMatchingCreationRules)
 	}
 
 	config, err := configFromRule(rule, kmsEncryptionContext)


### PR DESCRIPTION
Addresses #1790 — `sops --age <recipient> -e file` (or `--kms`/`--pgp`/etc.) fails with `error loading config: no matching creation rules found` whenever a `.sops.yaml` exists somewhere up the directory tree but none of its creation rules match the target file, even though the explicit key should be sufficient on its own. Reported against 3.9.4; still reproduces on current `main` / 3.13.3.

(Note: [one comment on #1790](https://github.com/getsops/sops/issues/1790#issuecomment-2789676661) also mentions `--output` not being matched against creation rules — that looks like a separate, related problem this PR doesn't touch.)

## Root cause

`keyGroups()` already does the right thing: if the caller passes `--age`/`--kms`/etc., it sources keys straight from those flags without consulting the config at all. But **three other call sites load the config unconditionally, before `keyGroups()` ever runs, and treat any loading failure as fatal**:

- `main()`'s `app.Action` (~line 1949) — loads config purely to read `EncryptedRegex`/`UnencryptedSuffix`/etc.
- `getEncryptConfig()` (~line 2134) — re-loads it again, for the same settings.
- `shamirThreshold()` (~line 2576) — loads it a third time, just for `ShamirThreshold`.

Every value these three read from config has a safe zero-value default — none of them actually *need* the config to exist, they only need to not crash when it doesn't apply. The command dies in one of these three before ever reaching the code (`keyGroups()`) that would have worked fine with just the CLI-supplied key.

## Fix

Export `config.ErrNoMatchingCreationRules` as a sentinel for that specific failure. At each of the three sites: if the error is that sentinel *and* the user supplied at least one key flag directly (the same condition `keyGroups()` already checks, now factored into a shared `hasExplicitKeyFlags()`), treat it as "no applicable config" instead of a hard error. A config that exists and *does* match is completely unaffected — this only changes the non-matching + explicit-key case.

## Verification

```
$ sops --encrypt --age age1... --input-type dotenv --output-type dotenv .env > .env.encrypted
error loading config: no matching creation rules found          # stock 3.13.3

$ ./sops-patched --encrypt --age age1... --input-type dotenv --output-type dotenv .env > .env.encrypted
$ ./sops-patched --decrypt --input-type dotenv --output-type dotenv .env.encrypted
# decrypts back to the exact original .env content — full round-trip verified
```

`go build ./...` and `go test ./config/... ./cmd/sops/...` both pass unchanged. `cmd/sops` has no existing unit tests covering this area (`[no test files]`) — happy to add table-driven tests for `hasExplicitKeyFlags`/the three call sites if that's wanted before merge, just say the word on shape/location.