### PR TITLE
Add --(un)encrypted-comment-regex options to 'sops encrypt'

### DIFF
--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -995,6 +995,14 @@ func main() {
 					Usage: "set the encrypted key regex. When specified, only keys matching the regex will be encrypted.",
 				},
 				cli.StringFlag{
+					Name:  "unencrypted-comment-regex",
+					Usage: "set the unencrypted comment suffix. When specified, only keys that have comment matching the regex will be left unencrypted.",
+				},
+				cli.StringFlag{
+					Name:  "encrypted-comment-regex",
+					Usage: "set the encrypted comment suffix. When specified, only keys that have comment matching the regex will be encrypted.",
+				},
+				cli.StringFlag{
 					Name:  "encryption-context",
 					Usage: "comma separated list of KMS encryption context key:value pairs",
 				},


### PR DESCRIPTION
While investigating #2281 I noticed that `sops encrypt` does not accept `--encrypted-comment-regex` and --unencrypted-comment-regex`, while `sops --encrypt` does. This makes `sops encrypt` also accept these options.