### PR TITLE
fix(dotenv): strip trailing carriage return when parsing CRLF files

### DIFF
--- a/stores/dotenv/store.go
+++ b/stores/dotenv/store.go
@@ -48,6 +48,7 @@ func (store *Store) LoadPlainFile(in []byte) (sops.TreeBranches, error) {
 	var branch sops.TreeBranch
 
 	for _, line := range bytes.Split(in, []byte("\n")) {
+		line = bytes.TrimSuffix(line, []byte("\r"))
 		if len(line) == 0 {
 			continue
 		}

--- a/stores/dotenv/store_test.go
+++ b/stores/dotenv/store_test.go
@@ -45,6 +45,18 @@ func TestLoadPlainFile(t *testing.T) {
 	assert.Equal(t, BRANCH, branches[0])
 }
 
+func TestLoadPlainFileCRLF(t *testing.T) {
+	in := []byte("VAR1=val1\r\nVAR2=val2\r\n#comment\r\n")
+	branches, err := (&Store{}).LoadPlainFile(in)
+	assert.NoError(t, err)
+	expected := sops.TreeBranch{
+		sops.TreeItem{Key: "VAR1", Value: "val1"},
+		sops.TreeItem{Key: "VAR2", Value: "val2"},
+		sops.TreeItem{Key: sops.Comment{Value: "comment"}, Value: nil},
+	}
+	assert.Equal(t, expected, branches[0])
+}
+
 func TestLoadEncryptedFileNoMetadata(t *testing.T) {
 	branches, err := (&Store{}).LoadEncryptedFile(PLAIN)
 	assert.Equal(t, err, sops.MetadataNotFound)


### PR DESCRIPTION
## What

Fix dotenv parsing so CRLF (`\r\n`) line endings no longer corrupt decrypted values.

`sops/stores/dotenv/store.go`'s `LoadPlainFile` splits input on `\n` but never strips the trailing `\r`. On files with Windows/CRLF line endings, every value ends up with a stray carriage return (`"val1\r"`), comments carry `\r`, and empty lines become `\r`-only lines that are treated as malformed input.

## Why

This is the same underlying symptom reported in #854, #1128, and #1157 — encrypted dotenv files that fail to decrypt (or silently corrupt values) after their line endings are converted to CRLF, e.g. by `git` on Windows.

## Fix

Strip a single trailing `\r` from each line before processing. This is additive and backward compatible: LF-only files behave exactly as before.

## Tests

Added `TestLoadPlainFileCRLF` asserting that a CRLF file with values and a comment parses identically to its LF counterpart. `go test ./stores/dotenv/` passes.

Signed-off-by: Mrxh <x1247897956@users.noreply.github.com>
