### PR TITLE
updatekeys: detect key ordering changes

### DIFF
--- a/cmd/sops/subcommand/updatekeys/updatekeys.go
+++ b/cmd/sops/subcommand/updatekeys/updatekeys.go
@@ -5,7 +5,9 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 
+	"github.com/getsops/sops/v3"
 	"github.com/getsops/sops/v3/cmd/sops/codes"
 	"github.com/getsops/sops/v3/cmd/sops/common"
 	"github.com/getsops/sops/v3/config"
@@ -60,12 +62,7 @@ func updateFile(opts Opts) error {
 	}
 
 	diffs := common.DiffKeyGroups(tree.Metadata.KeyGroups, conf.KeyGroups)
-	keysWillChange := false
-	for _, diff := range diffs {
-		if len(diff.Added) > 0 || len(diff.Removed) > 0 {
-			keysWillChange = true
-		}
-	}
+	keysWillChange := keyGroupsChanged(tree.Metadata.KeyGroups, conf.KeyGroups)
 
 	// TODO: use conf.ShamirThreshold instead of tree.Metadata.ShamirThreshold in the next line?
 	//       Or make this configurable?
@@ -83,6 +80,13 @@ func updateFile(opts Opts) error {
 	fmt.Printf("The following changes will be made to the file's groups:\n")
 	common.PrettyPrintShamirDiff(tree.Metadata.ShamirThreshold, shamirThreshold)
 	common.PrettyPrintDiffs(diffs)
+	for i, diff := range diffs {
+		if i < len(tree.Metadata.KeyGroups) && i < len(conf.KeyGroups) &&
+			len(diff.Added) == 0 && len(diff.Removed) == 0 &&
+			keyGroupsChanged(tree.Metadata.KeyGroups[i:i+1], conf.KeyGroups[i:i+1]) {
+			fmt.Printf("Key order changed in group %d\n", i+1)
+		}
+	}
 
 	if opts.Interactive {
 		var response string
@@ -123,6 +127,34 @@ func updateFile(opts Opts) error {
 	}
 	log.Printf("File %s synced with new keys", opts.InputPath)
 	return nil
+}
+
+// Keys are stored separately by type, preserving order only within each type.
+func keyGroupsChanged(current, desired []sops.KeyGroup) bool {
+	if len(current) != len(desired) {
+		return true
+	}
+	for i := range current {
+		if len(current[i]) != len(desired[i]) {
+			return true
+		}
+		currentByType := make(map[string][]string)
+		desiredByType := make(map[string][]string)
+		for _, key := range current[i] {
+			kind := key.TypeToIdentifier()
+			currentByType[kind] = append(currentByType[kind], key.ToString())
+		}
+		for _, key := range desired[i] {
+			kind := key.TypeToIdentifier()
+			desiredByType[kind] = append(desiredByType[kind], key.ToString())
+		}
+		for kind, keys := range currentByType {
+			if !slices.Equal(keys, desiredByType[kind]) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func min(a, b int) int {

--- a/cmd/sops/subcommand/updatekeys/updatekeys_test.go
+++ b/cmd/sops/subcommand/updatekeys/updatekeys_test.go
@@ -1,0 +1,163 @@
+package updatekeys
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	agecrypto "filippo.io/age"
+	"github.com/getsops/sops/v3"
+	"github.com/getsops/sops/v3/aes"
+	"github.com/getsops/sops/v3/age"
+	"github.com/getsops/sops/v3/cmd/sops/common"
+	"github.com/getsops/sops/v3/config"
+	"github.com/getsops/sops/v3/keyservice"
+	"github.com/getsops/sops/v3/pgp"
+	"github.com/getsops/sops/v3/stores/yaml"
+	"github.com/stretchr/testify/require"
+)
+
+type ageTestServer struct {
+	keyservice.Server
+	identities age.ParsedIdentities
+}
+
+func (s ageTestServer) Decrypt(_ context.Context, request *keyservice.DecryptRequest) (*keyservice.DecryptResponse, error) {
+	key, err := age.MasterKeyFromRecipient(request.Key.GetAgeKey().Recipient)
+	if err != nil {
+		return nil, err
+	}
+	key.SetEncryptedDataKey(request.Ciphertext)
+	s.identities.ApplyToMasterKey(key)
+	plaintext, err := key.Decrypt()
+	return &keyservice.DecryptResponse{Plaintext: plaintext}, err
+}
+
+func testKey(recipient string) *age.MasterKey {
+	return &age.MasterKey{Recipient: recipient}
+}
+
+func TestKeyGroupsChanged(t *testing.T) {
+	first := testKey("age1first")
+	second := testKey("age1second")
+
+	tests := []struct {
+		name    string
+		current []sops.KeyGroup
+		desired []sops.KeyGroup
+		changed bool
+	}{
+		{
+			name:    "same order",
+			current: []sops.KeyGroup{{first, second}},
+			desired: []sops.KeyGroup{{testKey("age1first"), testKey("age1second")}},
+			changed: false,
+		},
+		{
+			name:    "key order changes",
+			current: []sops.KeyGroup{{first, second}},
+			desired: []sops.KeyGroup{{testKey("age1second"), testKey("age1first")}},
+			changed: true,
+		},
+		{
+			name:    "group order changes",
+			current: []sops.KeyGroup{{first}, {second}},
+			desired: []sops.KeyGroup{{testKey("age1second")}, {testKey("age1first")}},
+			changed: true,
+		},
+		{
+			name:    "different type ordering is not persisted",
+			current: []sops.KeyGroup{{&pgp.MasterKey{Fingerprint: "fingerprint"}, first}},
+			desired: []sops.KeyGroup{{first, &pgp.MasterKey{Fingerprint: "fingerprint"}}},
+		},
+		{
+			name:    "key added",
+			current: []sops.KeyGroup{{first}},
+			desired: []sops.KeyGroup{{testKey("age1first"), testKey("age1second")}},
+			changed: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := keyGroupsChanged(test.current, test.desired); got != test.changed {
+				t.Fatalf("keyGroupsChanged() = %v, want %v", got, test.changed)
+			}
+		})
+	}
+}
+
+func TestUpdateKeysReordersAgeRecipients(t *testing.T) {
+	first, err := agecrypto.GenerateX25519Identity()
+	require.NoError(t, err)
+	second, err := agecrypto.GenerateX25519Identity()
+	require.NoError(t, err)
+	services := []keyservice.KeyServiceClient{keyservice.NewCustomLocalClient(ageTestServer{
+		identities: age.ParsedIdentities{first, second},
+	})}
+	store := yaml.NewStore(&config.YAMLStoreConfig{})
+	tree := sops.Tree{
+		Branches: sops.TreeBranches{{{Key: "secret", Value: "value"}}},
+		Metadata: sops.Metadata{KeyGroups: []sops.KeyGroup{{
+			testKey(first.Recipient().String()), testKey(second.Recipient().String()),
+		}}},
+	}
+	dataKey, errs := tree.GenerateDataKeyWithKeyServices(services)
+	require.Empty(t, errs)
+	cipher := aes.NewCipher()
+	require.NoError(t, common.EncryptTree(common.EncryptTreeOpts{Tree: &tree, Cipher: cipher, DataKey: dataKey}))
+	before, err := store.EmitEncryptedFile(tree)
+	require.NoError(t, err)
+	dir := t.TempDir()
+	input := filepath.Join(dir, "secret.yaml")
+	configuration := filepath.Join(dir, ".sops.yaml")
+	require.NoError(t, os.WriteFile(input, before, 0600))
+	rule := fmt.Sprintf("creation_rules:\n  - age: %s,%s\n", second.Recipient(), first.Recipient())
+	require.NoError(t, os.WriteFile(configuration, []byte(rule), 0600))
+	opts := Opts{InputPath: input, ConfigPath: configuration, KeyServices: services}
+	require.NoError(t, UpdateKeys(opts))
+	after, err := os.ReadFile(input)
+	require.NoError(t, err)
+	loaded, err := store.LoadEncryptedFile(after)
+	require.NoError(t, err)
+	require.Equal(t, second.Recipient().String(), loaded.Metadata.KeyGroups[0][0].ToString())
+	require.Equal(t, first.Recipient().String(), loaded.Metadata.KeyGroups[0][1].ToString())
+	require.Equal(t, tree.Branches, loaded.Branches)
+	require.Equal(t, tree.Metadata.MessageAuthenticationCode, loaded.Metadata.MessageAuthenticationCode)
+	_, err = common.DecryptTree(common.DecryptTreeOpts{Tree: &loaded, Cipher: cipher, KeyServices: opts.KeyServices})
+	require.NoError(t, err)
+	require.Equal(t, "value", loaded.Branches[0][0].Value)
+	// A second update must leave the file byte-for-byte unchanged.
+	require.NoError(t, UpdateKeys(opts))
+	again, err := os.ReadFile(input)
+	require.NoError(t, err)
+	require.Equal(t, after, again)
+}
+
+func TestUpdateKeysMixedTypesAlreadyCurrent(t *testing.T) {
+	identity, err := agecrypto.GenerateX25519Identity()
+	require.NoError(t, err)
+	store := yaml.NewStore(&config.YAMLStoreConfig{})
+	tree := sops.Tree{Branches: sops.TreeBranches{{{Key: "public", Value: "value"}}}, Metadata: sops.Metadata{
+		LastModified: time.Now().UTC(),
+		KeyGroups: []sops.KeyGroup{{testKey(identity.Recipient().String()),
+			&pgp.MasterKey{Fingerprint: "0123456789012345678901234567890123456789", CreationDate: time.Now().UTC()},
+		}},
+	}}
+	before, err := store.EmitEncryptedFile(tree)
+	require.NoError(t, err)
+	dir := t.TempDir()
+	input := filepath.Join(dir, "secret.yaml")
+	configuration := filepath.Join(dir, ".sops.yaml")
+	require.NoError(t, os.WriteFile(input, before, 0600))
+	rule := fmt.Sprintf("creation_rules:\n  - key_groups:\n      - age: [%s]\n        pgp: [0123456789012345678901234567890123456789]\n", identity.Recipient())
+	require.NoError(t, os.WriteFile(configuration, []byte(rule), 0600))
+	// No key service: the unchanged file must not require decryption.
+	require.NoError(t, UpdateKeys(Opts{InputPath: input, ConfigPath: configuration}))
+	after, err := os.ReadFile(input)
+	require.NoError(t, err)
+	require.Equal(t, before, after)
+}


### PR DESCRIPTION
`updatekeys` reports "File already up to date" when recipients are only reordered in `.sops.yaml`. Detect ordering changes within each key type so the requested order is written to the encrypted file. Differences in ordering between key types are ignored because serialization does not preserve them.

Tests cover a real age recipient reorder with successful decryption, unchanged ciphertext/MAC, repeat-update idempotence, and unchanged mixed PGP/age groups.

Validation on Windows with Go 1.25.8:
- `go test ./cmd/sops/subcommand/updatekeys ./cmd/sops/common ./stores/...`
- `go vet ./cmd/sops/subcommand/updatekeys`

The separate `config/TestLoadConfigFileWithAmbiguousPath` test fails on Windows on both the baseline and this branch. Full Linux CI has not been run locally.

Fixes #2269.
